### PR TITLE
bundle lock --add-platform x86_64-linuxコマンドを実行

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.7)
     psych (5.1.2)
       stringio
@@ -218,6 +220,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
## 概要
Herokuにアプリをデプロイするために、bundlerをHeroku環境（x86_64-linux）に対応させるコマンドを実行

## 原因と対処法（バグ修正の場合）
- bundlerがHeroku環境のプラットフォームである"x86_64-linux"に対応していなかったことで、Heroku側でGemがインストールできなかった。
## やったこと
* [x] bundle lock --add-platform x86_64-linuxコマンドを実行し、bundlerがx86_64-linux上で正常に動作するような変更を加えた。


