### PR TITLE
railsのジェネレータで余分なファイルが設定されないよう変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,11 @@ module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
+    config.generators do |g|
+      g.helper false
+      g.skip_routes true
+      g.test_framework false
+    end
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'jins/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'jins/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
## 概要
rails g コマンドで余分なファイルが作成されないように設定を変更する。
## 問題点
- rails g コマンドを実行すると以下のファイルやコードが追加されてしまう。
  - test用のファイル(test/controllers/コントローラ名_test.rb)
  - ヘルパーファイル
  - ルーティングの追加
## やったこと
* [x] /config/application.rbファイルに上記のファイル・コードを追加しないようにする設定を追加した。

## 変更結果
**rails g controller jins index**の実行結果
- before
<img src="https://i.gyazo.com/13c304d16890a0d1948fd06a8771c2e1.png" width="500">
- after
<img src="https://i.gyazo.com/c9b6fa129cb18c82d7d1e63f256bf172.png" width="500">

## 関連Issue
Closes #11 