### PR TITLE
before_login_headerのimage_tagを用いてlogoを参照する部分を修正

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <div class="p-3 flex justify-between items-center bg-sky-100">
     <%= link_to root_path, class:"btn btn-outline bg-white text-center text-black" do %>
-      <%= image_tag "logo", size:"40x40" %>
+      <%= image_tag "logo.jpg", size:"40x40" %>
       <p>
         Morning Routine Hub
       </p>


### PR DESCRIPTION
## 概要
before_login_headerのimage_tagを用いてlogoを参照する部分を、Heroku上で正常に動作するように修正

## 問題点
ローカルではlogoが表示されているが、Heroku上では以下のエラーが発生していた。
-  ActionView::Template::Error (The asset "logo" is not present in the asset pipeline.

## やったこと
- image_tagで画像ファイル名を参照する際、拡張子を指定するように変更
## 参考記事
[【2022年版】HerokuでRailsの画像が表示されないときの適切な対処法（と間違った対処法）](https://qiita.com/jnchito/items/3d225112a3ac95379b1d)