### PR TITLE
Routinesテーブルを作成

### DIFF
--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -1,0 +1,6 @@
+class Routine < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true, length: { maxmum: 255 }
+  validates :description, length: { maxmum: 500 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :routines, dependent: :destroy
 
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/db/migrate/20240817154342_create_routines.rb
+++ b/db/migrate/20240817154342_create_routines.rb
@@ -1,0 +1,16 @@
+class CreateRoutines < ActiveRecord::Migration[7.0]
+  def change
+    create_table :routines do |t|
+      t.references :user, foreign_key: true
+      t.string :title, null:false
+      t.text :description
+      t.time :start_time
+      t.boolean :is_active, default:false
+      t.boolean :is_posted, default:false
+      t.integer :completed_count
+      t.integer :copied_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_16_121658) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_17_154342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "routines", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "title", null: false
+    t.text "description"
+    t.time "start_time"
+    t.boolean "is_active", default: false
+    t.boolean "is_posted", default: false
+    t.integer "completed_count"
+    t.integer "copied_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_routines_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -26,4 +40,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_16_121658) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "routines", "users"
 end


### PR DESCRIPTION
## 概要
DBにRoutinesテーブルを追加し、Routineモデルを作成する

## やったこと
- routinesテーブルをDBに追加する
- app/models/routine.rbを作成する
- バリデーションを作成する
- Userモデルとのアソシエーションを追加する
## 注意点
Heroku側ではmigrationファイルが適応されていないので、rake db:migrateを実行する必要がある。
## Issue
closes #30 