### PR TITLE
タイムゾーンの設定を追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,11 @@ module App
       g.skip_routes true
       g.test_framework false
     end
+
+    #97 タイムゾーンを設定する
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
+    
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
Railsアプリの設定にTZ設定を追加
## やったこと
- RailsアプリのタイムゾーンをTokyoに設定する
- ActiveRecordでDBからデータを読み込む際のタイムゾーンをアプリケーションが動作しているマシンのタイムゾーンに従う設定を追加する

## 注意点
- Herokuマシンのタイムゾーンを変更する必要がある

## 変更結果
<img src="https://i.gyazo.com/6d89d9a2534b5ef5b5afa156abddd738.png">
## issue
closes #97 