### PR TITLE
ルーティン一覧画面を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
   <head>
     <title>App</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -1,6 +1,7 @@
 <div>
   <h1 class="text-center text-3xl py-5">おはようございます！</h1>
 </div>
-<div class="container w-3/4 mx-auto text-center">
-  <%= link_to "ルーティンを作成する", new_routine_path, class:"btn btn-outline btn-success btn-md glass" %>
+<div class="w-3/4 mx-auto">
+  <%= link_to "ルーティンを作成する", new_routine_path, class:"btn btn-outline btn-success btn-md glass mx-2" %>
+  <%= link_to "ルーティン一覧", routines_path, class:"btn btn-outline btn-success btn-md glass mx-2" %>
 </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -1,44 +1,43 @@
-<div class="border py-3 w-4/5">
+<div class="border border-amber-300 p-3 w-1/2 my-5 mx-auto bg-sky-100 bg-opacity-50">
 
-  <div class="flex justify-between items-center mb-5">
-    <h1 class="text-2xl"><%= routine.title %></h1>
-    <div class="gap-4 flex">
-      <%= link_to "詳細", "#", class: "btn btn-outline btn-info btn-sm" %>
-      <%= link_to "削除", "#", class: "btn btn-outline btn-default btn-sm" %>
+  <div class="flex justify-between items-center mb-5 mx-3">
+    <h1 class="text-3xl border-b border-cyan-300"><%= routine.title %></h1>
+    <div class="flex">
+      <%= link_to "詳細", "#", class: "btn btn-outline btn-info btn-md mx-3" %>
+      <%= link_to "削除", "#", class: "btn btn-outline btn-error btn-md" %>
     </div>
   </div>
 
-  <div class="mb-5">
+  <div class="mb-5 bg-white p-5">
     <p><%= routine.description %></p>
   </div>
   
-  <div class="flex gap-x-5 mb-5 items-center">
-    <p>"開始時間: #{<%= routine.start_time %>}"</p>
-    <p>"目安達成時間:"</p>
-    <p>"達成回数： #{<%= routine.completed_count %>}"</p>
+  <div class="mb-5 items-center">
+    <p>開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+    <p>目安達成時間:</p>
+    <p>達成回数： <%= routine.completed_count %></p>
   </div>
 
-  <div class="flex justify-between">
-    <details class="collapse bg-base-200">
-      <summary class="collapse-title text-xl font-medium">タスク一覧</summary>
-      <div class="collapse-content">
-        <p>タスク情報を表示</p>
-      </div>
-    </details>
-
-    <div class="flex gap-4">
+  <div class="flex justify-end mb-5">
+    <div class="flex">
       <% if routine.is_active? %>
-        <%= link_to "投稿済み", "#", class: "btn btn-outline btn-default btn-sm" %>
+        <%= link_to "投稿済み", "#", class: "btn btn-outline btn-default btn-md mx-3" %>
       <% else %>
-        <%= link_to "投稿する", "#", class: "btn btn-outline btn-info btn-sm" %>
+        <%= link_to "投稿する", "#", class: "btn btn-outline btn-info btn-md mx-3" %>
       <% end %>
 
       <% if routine.is_active? %>
-        <%= link_to "実践中", "#", class: "btn btn-outline btn-default btn-sm" %>
+        <%= link_to "実践中", "#", class: "btn btn-outline btn-default btn-md" %>
       <% else %>
-        <%= link_to "実践する", "#", class: "btn btn-outline btn-primary btn-sm" %>
+        <%= link_to "実践する", "#", class: "btn btn-outline btn-accent btn-md" %>
       <% end %>
     </div>
   </div>
+  <details class="collapse bg-white">
+    <summary class="collapse-title font-medium">タスク一覧</summary>
+    <div class="collapse-content">
+      <p>タスク情報を表示</p>
+    </div>
+  </details>
 
 </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -1,0 +1,44 @@
+<div class="border py-3 w-4/5">
+
+  <div class="flex justify-between items-center mb-5">
+    <h1 class="text-2xl"><%= routine.title %></h1>
+    <div class="gap-4 flex">
+      <%= link_to "詳細", "#", class: "btn btn-outline btn-info btn-sm" %>
+      <%= link_to "削除", "#", class: "btn btn-outline btn-default btn-sm" %>
+    </div>
+  </div>
+
+  <div class="mb-5">
+    <p><%= routine.description %></p>
+  </div>
+  
+  <div class="flex gap-x-5 mb-5 items-center">
+    <p>"開始時間: #{<%= routine.start_time %>}"</p>
+    <p>"目安達成時間:"</p>
+    <p>"達成回数： #{<%= routine.completed_count %>}"</p>
+  </div>
+
+  <div class="flex justify-between">
+    <details class="collapse bg-base-200">
+      <summary class="collapse-title text-xl font-medium">タスク一覧</summary>
+      <div class="collapse-content">
+        <p>タスク情報を表示</p>
+      </div>
+    </details>
+
+    <div class="flex gap-4">
+      <% if routine.is_active? %>
+        <%= link_to "投稿済み", "#", class: "btn btn-outline btn-default btn-sm" %>
+      <% else %>
+        <%= link_to "投稿する", "#", class: "btn btn-outline btn-info btn-sm" %>
+      <% end %>
+
+      <% if routine.is_active? %>
+        <%= link_to "実践中", "#", class: "btn btn-outline btn-default btn-sm" %>
+      <% else %>
+        <%= link_to "実践する", "#", class: "btn btn-outline btn-primary btn-sm" %>
+      <% end %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -1,0 +1,8 @@
+<div class="container w-3/5 text-center mx-auto mt-5">
+  <% if @routines.empty? %>
+    <p class="text-center">ルーティンを作成しましょう！！</p>
+    <%= link_to "ルーティンを作成する", new_routine_path, class:"btn btn-outline btn-success btn-md glass" %>
+  <% else %>
+    <%= render @routines %>
+  <% end %>
+</div>

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -1,7 +1,7 @@
-<div class="container w-3/5 text-center mx-auto mt-5">
+<div class="mt-5">
+  <%= link_to "ルーティンを作成する", new_routine_path, class:"btn btn-outline btn-success btn-md right-10 absolute " %>
   <% if @routines.empty? %>
     <p class="text-center">ルーティンを作成しましょう！！</p>
-    <%= link_to "ルーティンを作成する", new_routine_path, class:"btn btn-outline btn-success btn-md glass" %>
   <% else %>
     <%= render @routines %>
   <% end %>


### PR DESCRIPTION
## 概要
ルーティン一覧機能を実装するため、ログインユーザーが作成したルーティン一覧を表示するViewを追加する

## やったこと
- app/views/routines/index.html.erbを作成する
- マイページから遷移する
- アプリのテーマを"light"に変更する

## 変更結果
<img src="https://i.gyazo.com/9206b4dca98bded93453396b8cb7f900.png">


## 問題点
* [ ] 1つのルーティン表示が大きすぎて見えづらい
* [ ] 色の組み合わせが見えづらい
## Issue
closes #35 