### PR TITLE
ルーティン削除機能を実装

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -32,6 +32,7 @@ class RoutinesController < ApplicationController
 
   def destroy
     @routine.destroy!
+    flash[:alert] = "#{@routine.title}を削除しました"
     redirect_to routines_path, status: :see_other
   end
 

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -1,5 +1,5 @@
 class RoutinesController < ApplicationController
-  before_action :set_routine, only: %i[ edit update ]
+  before_action :set_routine, only: %i[ edit update destroy ]
 
   def index
     @routines = current_user.routines.order(created_at: :desc)
@@ -28,6 +28,11 @@ class RoutinesController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @routine.destroy!
+    redirect_to routines_path, status: :see_other
   end
 
   private

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -5,7 +5,7 @@
     <div class="flex">
       <%= link_to "編集", edit_routine_path(routine), class: "btn btn-outline btn-success btn-md mr-3" %>
       <%= link_to "詳細", "#", class: "btn btn-outline btn-info btn-md mr-3" %>
-      <%= link_to "削除", "#", class: "btn btn-outline btn-error btn-md" %>
+      <%= link_to "削除", routine_path(routine), data: { turbo_method: :delete }, class: "btn btn-outline btn-error btn-md" %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :routines, only: %i[ index new create edit update ]
+  resources :routines, only: %i[ index new create edit update destroy ]
 end


### PR DESCRIPTION
## 概要
ルーティン削除機能を実装するため、routines_controllerにdestroyアクションを追加する
## やったこと
- routines_controllerにdestroyアクションを追加する
- ルーティングを追加する
- ルーティン一覧画面の削除ボタンから遷移する
## 削除処理
- 削除する際は関連付けたデータも同時に削除したいので、DBから削除する処理はdestroy!アクションを使用する
- 参考：[[Rails]deleteメソッドとdestroyメソッドの違いについて！！[初心者]](https://qiita.com/jackie0922youhei/items/588cd6f62cb1ff9e9809)
## 変更結果
- 削除前
<img src="https://i.gyazo.com/9f54d2892497a3e709c09ddc3c4d794a.png">

- 削除後
<img src="https://i.gyazo.com/32e14b3ebaf554d19ac97d914120c417.png">

## Issue
closes #40 
