### PR TITLE
ルーティンを実践中にする機能を追加

### DIFF
--- a/app/controllers/routines/actives_controller.rb
+++ b/app/controllers/routines/actives_controller.rb
@@ -1,12 +1,12 @@
 class Routines::ActivesController < ApplicationController
 
-  def create
-    # 現在実践中のルーティンを実践前状態に変更
-    routine_active_now = Routine.find_by(is_active: true)
-    routine_active_now.update!(is_active: false) if routine_active_now
-
+  def update
     routine = Routine.find(params[:routine_id])
-    routine.update!(is_active: true)
+    routine_active_now = Routine.find_by(is_active: true)
+    unless routine == routine_active_now
+        routine_active_now.update!(is_active: false) if routine_active_now
+        routine.update!(is_active: true)
+    end
     redirect_to routines_path
   end
 end

--- a/app/controllers/routines/actives_controller.rb
+++ b/app/controllers/routines/actives_controller.rb
@@ -1,0 +1,12 @@
+class Routines::ActivesController < ApplicationController
+
+  def create
+    # 現在実践中のルーティンを実践前状態に変更
+    routine_active_now = Routine.find_by(is_active: true)
+    routine_active_now.update!(is_active: false) if routine_active_now
+
+    routine = Routine.find(params[:routine_id])
+    routine.update!(is_active: true)
+    redirect_to routines_path
+  end
+end

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -21,16 +21,16 @@
 
   <div class="flex justify-end mb-5">
     <div class="flex">
-      <% if routine.is_active? %>
+      <% if routine.is_posted? %>
         <%= link_to "投稿済み", "#", class: "btn btn-outline btn-default btn-md mx-3" %>
       <% else %>
         <%= link_to "投稿する", "#", class: "btn btn-outline btn-info btn-md mx-3" %>
       <% end %>
 
       <% if routine.is_active? %>
-        <%= link_to "実践中", "#", class: "btn btn-outline btn-default btn-md" %>
+        <%= link_to "実践中", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn btn-outline btn-default btn-md" %>
       <% else %>
-        <%= link_to "実践する", "#", class: "btn btn-outline btn-accent btn-md" %>
+        <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn btn-outline btn-accent btn-md" %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,7 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :routines, only: %i[ index new create edit update destroy ]
+  namespace :routines do
+    resources :actives, only: %i[ update ], param: :routine_id
+  end
 end


### PR DESCRIPTION
## 概要
ルーティンを実践中にする機能を実装するため、Routines::ActivesControllerを作成する
## 概要
- app/controllers/routines/actives_controller.rbを作成する
- updateアクションを作成する
- 「PATCH  /routines/actives/:routine_id(.:format)」 のようなURLが生成されるようにルーティングを設定する
- ルーティン一覧画面から遷移する

## 変更結果
<img src="https://i.gyazo.com/72d169b61f431b01eb578c5a9f9529c8.png">

<img src="https://i.gyazo.com/c59f2ec040b62892c84446ff603838f7.png">

## Issue
closes #41 
