### PR TITLE
scopeメソッドを削除

### DIFF
--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -1,5 +1,5 @@
 class MyPagesController < ApplicationController
   def index
-    @routine = current_user.routines.active
+    @routine = current_user.routines.find_by(is_active: true)
   end
 end

--- a/app/controllers/routines/actives_controller.rb
+++ b/app/controllers/routines/actives_controller.rb
@@ -2,7 +2,7 @@ class Routines::ActivesController < ApplicationController
 
   def update
     routine = current_user.routines.find(params[:routine_id])
-    routine_active_now = current_user.routines.active
+    routine_active_now = current_user.routines.find_by(is_active: true)
     unless routine == routine_active_now
         routine_active_now.update!(is_active: false) if routine_active_now
         routine.update!(is_active: true)

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -3,6 +3,4 @@ class Routine < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 500 }
-
-  scope :active, -> { find_by(is_active: true) }
 end

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -7,5 +7,13 @@
 </div>
 
 <div class="my-5">
-  <%= render "routine", routine: @routine %>
+  <% if @routine %>
+    <%= render "routine", routine: @routine %>
+  <% else %>
+    <div class="text-center items-center">
+      <%= link_to routines_path, class:"items-center btn bg-yellow-400" do %>
+        <p class="text-xl">ルーティンを実践中にしましょう！！</p>
+      <% end %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## 概要
scopeメソッドでfind_byを使用している部分を削除し、バグを修正する

## 原因
- scopeメソッドはActiveRecord::Relationオブジェクトを返すことを目的としているが、find_byは対象が存在しない場合nilを返す。nilが返された場合、scopeはnilの代わりにテーブルの全レコードを返す処理を行うため、処理がおかしくなっている。
## やったこと
- routineモデルのscopeメソッドで定義した処理を削除し、各コントローラでfind_byを用いた記述に置き換える。
## issue
FIX #42 