### PR TITLE
Tasks tableをDBに追加する

### DIFF
--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -1,5 +1,6 @@
 class Routine < ApplicationRecord
   belongs_to :user
+  has_many :tasks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 500 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,6 @@
+class Task < ApplicationRecord
+  belongs_to :routine
+
+  validates :title, presence: true, length: { maximun: 50 }
+  validates :estimated_time_in_second, presence: true
+end

--- a/db/migrate/20240820091606_create_tasks.rb
+++ b/db/migrate/20240820091606_create_tasks.rb
@@ -1,0 +1,12 @@
+class CreateTasks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tasks do |t|
+      t.string :title, null: false, limit: 50
+      t.integer :estimated_time_in_second, null: false
+      t.references :routine, foreign_key: true
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_17_154342) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_20_091606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_17_154342) do
     t.index ["user_id"], name: "index_routines_on_user_id"
   end
 
+  create_table "tasks", force: :cascade do |t|
+    t.string "title", limit: 50, null: false
+    t.integer "estimated_time_in_second", null: false
+    t.bigint "routine_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["routine_id"], name: "index_tasks_on_routine_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -41,4 +51,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_17_154342) do
   end
 
   add_foreign_key "routines", "users"
+  add_foreign_key "tasks", "routines"
 end


### PR DESCRIPTION
## 概要
ルーティンに属するTaskデータを管理するため、DBにTasksテーブルを作成し、Taskモデルを作成する
##やったこと
- tasksテーブルをDBに追加する
- taskモデルを作成する
- DB制約、バリデーションを設定する
- アソシエーションを設定する
## Issue
#46 