### PR TITLE
acts_as_listの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ ruby "3.3.4"
 
 #9 tailswindを導入
 gem "cssbundling-rails"
-
 #16 ユーザー登録機能
 gem "sorcery"
+#47 タスクの並べ替え機能
+gem "acts_as_list"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts_as_list (1.2.2)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
@@ -259,6 +262,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_list
   bootsnap
   capybara
   cssbundling-rails

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :routine
+  acts_as_list scope: :routine
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :estimated_time_in_second, presence: true


### PR DESCRIPTION
## 概要
タスクの並べ替え機能を実装するため、gem "acts_as_list"を導入する
## やったこと
- acts_as_listをインストールする
- taskモデルに適応する
## Issue
closes #47 