### PR TITLE
task作成フォームを実装

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -21,6 +21,7 @@ class RoutinesController < ApplicationController
 
   def show
     @task = Task.new
+    @tasks = @routine.tasks
   end
 
   def edit; end

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -20,6 +20,7 @@ class RoutinesController < ApplicationController
   end
 
   def show
+    @task = Task.new
   end
 
   def edit; end

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -2,7 +2,7 @@ class RoutinesController < ApplicationController
   before_action :set_routine, only: %i[ show edit update destroy ]
 
   def index
-    @routines = current_user.routines.order(created_at: :desc)
+    @routines = current_user.routines.includes(:tasks).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,10 +3,10 @@ class TasksController < ApplicationController
 
   def create
     @routine = current_user.routines.find(params[:routine_id])
-    @task = routine.tasks.new(task_params)
+    @task = @routine.tasks.new(task_params)
     if @task.save
       flash[:notice] = "タスクを追加しました"
-      redirect_to routine_path(routine)
+      redirect_to routine_path(@routine)
     else
       @tasks = routine.tasks.order(created_at: :desc)
       render template: "routines/show", status: :unprocessable_entity
@@ -20,9 +20,9 @@ class TasksController < ApplicationController
   end
 
   def params_time_to_second
-    hour = params[:task][:hour] * 3600
-    minute = params[:task][:minute] * 60
-    second = params[:task][:second]
+    hour = params[:task][:hour].to_i * 3600
+    minute = params[:task][:minute].to_i * 60
+    second = params[:task][:second].to_i
     params[:task][:estimated_time_in_second] = hour + minute + second
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,17 @@ class Task < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :estimated_time_in_second, presence: true
+
+  def estimated_time
+    result = Hash.new
+    value = estimated_time_in_second
+
+    result[:hour] = value / 3600
+    value -= result[:hour] * 3600
+    result[:minute] = value / 60
+    value -= result[:minute] * 60
+    result[:second] = value
+
+    return result
+  end
 end

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -37,7 +37,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <p>タスク情報を表示</p>
+      <%= render partial: "task", collection: routine.tasks %>
     </div>
   </details>
 

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -1,0 +1,22 @@
+<div class="border border-green-300 p-2 mb-3">
+  <div class="flex justify-between items-center mb-5 mx-3">
+    <h1 class="text-xl border-b border-cyan-300"><%= task.title %></h1>
+    <div class="flex">
+      <%= link_to "編集", "#", class: "btn btn-outline text-green-400 btn-sm mr-3" %>
+      <%= link_to "削除", "#", class: "btn btn-outline text-red-300 btn-sm" %>
+    </div>
+  </div>
+  <div class="flex">
+    <p class="mr-3">目安時間：</p>
+    <p class="mx-2">
+      <%= task.estimated_time[:hour] %> h
+    </p>
+    <p class="mx-2">
+      <%= task.estimated_time[:minute] %> m
+    </p>
+    <p class="mx-2">
+      <%= task.estimated_time[:second] %> s
+    </p>
+  </div>
+
+</div>

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: task, url: routine_tasks_path(routine.id), class:"text-center" do |f| %>
+  <div class="mb-5">
+    <%= f.label :title, "タイトル" %> <br>
+    <%= f.text_field :title, class:"border w-1/2" %>
+  </div>
+
+  <p class="mb-1">目安時間:</p>
+  <div class="flex justify-center mb-5">  
+    <%= f.number_field :hour, class: "w-1/6 border", min: 0, max: 23 %>
+    <span class="px-2">h</span>
+    <%= f.number_field :minute, class: "w-1/6 border", min: 0, max: 59 %>
+    <span class="px-2">m</span>
+    <%= f.number_field :second, class: "w-1/6 border", min: 0, max: 59 %>
+    <span class="px-2">s</span>
+  </div>
+
+  <%= f.submit "送信", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+<% end %>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -20,7 +20,7 @@
 
   
   <div class="text-center p-5 bg-gray-100">
-    <p class="mb-5">タスク情報を表示</p>
+    <%= render partial: "task", collection: @tasks %>
     <button class="btn bg-green-100 w-full text-center" onclick="task_form.showModal()">タスクを追加</button>
     <dialog id="task_form" class="modal">
       <div class="modal-box">

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -17,12 +17,24 @@
     <p class="mr-5">達成回数： <%= @routine.completed_count %></p>
   </div>
 
-  <details class="collapse bg-white my-5">
-    <summary class="collapse-title font-medium">タスク一覧</summary>
-    <div class="collapse-content">
-      <p>タスク情報を表示</p>
-    </div>
-  </details>
+
+  
+  <div class="text-center p-5 bg-gray-100">
+    <p class="mb-5">タスク情報を表示</p>
+    <button class="btn bg-green-100 w-full text-center" onclick="task_form.showModal()">タスクを追加</button>
+    <dialog id="task_form" class="modal">
+      <div class="modal-box">
+        <h1 class="text-center text-xl mb-10">タスク新規作成</h1>
+        <%= render "task_form", task: @task, routine: @routine %>
+        <div class="modal-action">
+          <form method="dialog">
+            <button class="btn">閉じる</button>
+          </form>
+        </div>
+      </div>
+    </dialog>
+  </div>
+
 
 </div>
 


### PR DESCRIPTION
## 概要
Tasksテーブルにレコードを追加するためのtask情報入力フォームを作成する
## やったこと
- ルーティン詳細画面に「タスクを追加」ボタンを設置する
- ボタンを押すとタスク作成フォームがモーダル表示される
- ルーティン詳細画面、ルーティン一覧画面にそのルーティンに属するtask情報を表示する
- tasks tableのestimated_time_in_secondカラムの値は"Oh Om Os"の形式で表示する

## 変更結果
<img src="https://i.gyazo.com/f0d45478e5c0cf1396504ace88d5e615.png">
<img src="https://i.gyazo.com/f6e27c263c5f0a72ffe7bb15fa2a73e8.png">

## Issue
closes #50 