### PR TITLE
タスク情報をマイページに表示

### DIFF
--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -1,5 +1,5 @@
 class MyPagesController < ApplicationController
   def index
-    @routine = current_user.routines.find_by(is_active: true)
+    @routine = current_user.routines.includes(:tasks).find_by(is_active: true)
   end
 end

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -22,7 +22,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <p>タスク情報を表示</p>
+      <%= render partial: "task", collection: routine.tasks %>
     </div>
   </details>
 

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -1,0 +1,22 @@
+<div class="border border-green-300 p-2 mb-3">
+  <div class="flex justify-between items-center mb-5 mx-3">
+    <h1 class="text-xl border-b border-cyan-300"><%= task.title %></h1>
+    <div class="flex">
+      <%= link_to "編集", "#", class: "btn btn-outline text-green-400 btn-sm mr-3" %>
+      <%= link_to "削除", "#", class: "btn btn-outline text-red-300 btn-sm" %>
+    </div>
+  </div>
+  <div class="flex">
+    <p class="mr-3">目安時間：</p>
+    <p class="mx-2">
+      <%= task.estimated_time[:hour] %> h
+    </p>
+    <p class="mx-2">
+      <%= task.estimated_time[:minute] %> m
+    </p>
+    <p class="mx-2">
+      <%= task.estimated_time[:second] %> s
+    </p>
+  </div>
+
+</div>


### PR DESCRIPTION
## 概要
マイページにタスク情報を表示する
## やったこと
- マイページの実践中のルーティンを表示する部分に、task情報を表示する
## 変更結果
<img src="https://i.gyazo.com/775f6ef1af3b76e8c9e36421b912ee63.png">

