### PR TITLE
タスク編集フォームを作成

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -44,7 +44,7 @@ class RoutinesController < ApplicationController
   private
 
   def routine_params
-    params.require(:routine).permit(:title, :description, :start_time, :completed_count, :copied_count)
+    params.require(:routine).permit(:title, :description, :start_time)
   end
 
   def set_routine

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,20 +1,21 @@
 class TasksController < ApplicationController
-  before_action :set_routine
   before_action :params_time_to_second
   
   def create
+    @routine = current_user.routines.find(params[:routine_id])
     @task = @routine.tasks.new(task_params)
     if @task.save
       flash[:notice] = "タスクを追加しました"
       redirect_to routine_path(@routine)
     else
-      @tasks = routine.tasks.order(created_at: :desc)
+      @tasks = @routine.tasks.order(created_at: :desc)
       render template: "routines/show", status: :unprocessable_entity
     end
   end
 
   def update
     @task = Task.find(params[:id])
+    @routine = @task.routine
     if @task.update(task_params)
       flash[:notice] = "taskを更新しました"
       redirect_to routine_path(@routine)
@@ -26,10 +27,6 @@ class TasksController < ApplicationController
 
   private
 
-  def set_routine
-    @routine = current_user.routines.find(params[:routine_id])
-  end
-
   def task_params
     params.require(:task).permit(:title, :estimated_time_in_second)
   end
@@ -39,5 +36,9 @@ class TasksController < ApplicationController
     minute = params[:task][:minute].to_i * 60
     second = params[:task][:second].to_i
     params[:task][:estimated_time_in_second] = hour + minute + second
+
+    params[:task].delete(:hour)
+    params[:task].delete(:minute)
+    params[:task].delete(:second)
   end
 end

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="mx-auto my-8">
     <%= f.label :start_time, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.time_field :start_time, class:"grow", placeholder: "06:30", min: "00:00", max: "23:59" %>
+      <%= f.time_field :start_time, class:"grow", min: "00:00", max: "23:59" %>
     <% end %>
   </div>
 

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -17,13 +17,5 @@
     <% end %>
   </div>
 
-  <% if routine.id %>
-    <%= f.hidden_field :completed_count, value: routine.completed_count %>
-    <%= f.hidden_field :copied_count, value: routine.copied_count %>
-  <% else %>
-    <%= f.hidden_field :completed_count, value: "0" %>
-    <%= f.hidden_field :copied_count, value: "0" %>
-  <% end %>
-
   <%= f.submit nil, class:"btn btn-outline btn-accent mb-5 w-1/3" %>
 <% end %>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -37,7 +37,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <%= render partial: "task", collection: routine.tasks %>
+      <%= render partial: "task", collection: routine.tasks, locals: { routine: routine } %>
     </div>
   </details>
 

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -2,10 +2,22 @@
   <div class="flex justify-between items-center mb-5 mx-3">
     <h1 class="text-xl border-b border-cyan-300"><%= task.title %></h1>
     <div class="flex">
-      <%= link_to "編集", "#", class: "btn btn-outline text-green-400 btn-sm mr-3" %>
+      <button class="btn btn-outline text-blue-400 btn-sm mr-3" onclick="document.querySelector('#edit_task_form').showModal()">編集</button>
+      <dialog id="edit_task_form" class="modal">
+        <div class="modal-box">
+          <h1 class="text-center text-xl mb-10">タスク編集</h1>
+          <%= render partial: "routines/task_form", locals: { task: task, routine: routine } %>
+          <div class="modal-action">
+            <form method="dialog">
+              <button class="btn">キャンセル</button>
+            </form>
+          </div>
+        </div>
+      </dialog>
       <%= link_to "削除", "#", class: "btn btn-outline text-red-300 btn-sm" %>
     </div>
   </div>
+
   <div class="flex">
     <p class="mr-3">目安時間：</p>
     <p class="mx-2">

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: task, url: routine_tasks_path(routine.id), class:"text-center" do |f| %>
+<%= form_with model: task, url: task.new_record? ? routine_tasks_path(routine) : task_path(task), class:"text-center" do |f| %>
   <div class="mb-5">
     <%= f.label :title, "タイトル" %> <br>
     <%= f.text_field :title, class:"border w-1/2" %>
@@ -6,13 +6,13 @@
 
   <p class="mb-1">目安時間:</p>
   <div class="flex justify-center mb-5">  
-    <%= f.number_field :hour, class: "w-1/6 border", min: 0, max: 23 %>
+    <%= f.number_field :hour, class: "w-1/6 border", min: 0, max: 23, value: task.estimated_time[:hour] %>
     <span class="px-2">h</span>
-    <%= f.number_field :minute, class: "w-1/6 border", min: 0, max: 59 %>
+    <%= f.number_field :minute, class: "w-1/6 border", min: 0, max: 59, value: task.estimated_time[:minute] %>
     <span class="px-2">m</span>
-    <%= f.number_field :second, class: "w-1/6 border", min: 0, max: 59 %>
+    <%= f.number_field :second, class: "w-1/6 border", min: 0, max: 59, value: task.estimated_time[:second] %>
     <span class="px-2">s</span>
   </div>
 
-  <%= f.submit "送信", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+  <%= f.submit "確定", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
 <% end %>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -7,6 +7,7 @@
       <%= link_to "削除", routine_path(@routine), data: { turbo_method: :delete }, class: "btn btn-outline btn-error btn-md" %>
     </div>
   </div>
+
   <div class="my-5 bg-white p-2">
     <p class="py-1">説明文：</p>
     <p><%= @routine.description %></p>
@@ -20,12 +21,12 @@
 
   
   <div class="text-center p-5 bg-gray-100">
-    <%= render partial: "task", collection: @tasks %>
+    <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine } %>
     <button class="btn bg-green-100 w-full text-center" onclick="task_form.showModal()">タスクを追加</button>
     <dialog id="task_form" class="modal">
       <div class="modal-box">
         <h1 class="text-center text-xl mb-10">タスク新規作成</h1>
-        <%= render "task_form", task: @task, routine: @routine %>
+        <%= render "routines/task_form", task: @task, routine: @routine %>
         <div class="modal-action">
           <form method="dialog">
             <button class="btn">閉じる</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :routines do
-    resources :tasks, only: %i[ create update ]
+    resources :tasks, only: %i[ create update ], shallow: true
   end
 
   namespace :routines do

--- a/db/migrate/20240817154342_create_routines.rb
+++ b/db/migrate/20240817154342_create_routines.rb
@@ -4,11 +4,11 @@ class CreateRoutines < ActiveRecord::Migration[7.0]
       t.references :user, foreign_key: true
       t.string :title, null:false
       t.text :description
-      t.time :start_time
+      t.time :start_time, default: "07:00:00"
       t.boolean :is_active, default:false
       t.boolean :is_posted, default:false
-      t.integer :completed_count
-      t.integer :copied_count
+      t.integer :completed_count, default: 0
+      t.integer :copied_count, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20240820091606_create_tasks.rb
+++ b/db/migrate/20240820091606_create_tasks.rb
@@ -2,7 +2,7 @@ class CreateTasks < ActiveRecord::Migration[7.0]
   def change
     create_table :tasks do |t|
       t.string :title, null: false, limit: 50
-      t.integer :estimated_time_in_second, null: false
+      t.integer :estimated_time_in_second, null: false, default: 60
       t.references :routine, foreign_key: true
       t.integer :position
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,11 +18,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_20_091606) do
     t.bigint "user_id"
     t.string "title", null: false
     t.text "description"
-    t.time "start_time"
+    t.time "start_time", default: "2000-01-01 07:00:00"
     t.boolean "is_active", default: false
     t.boolean "is_posted", default: false
-    t.integer "completed_count"
-    t.integer "copied_count"
+    t.integer "completed_count", default: 0
+    t.integer "copied_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_routines_on_user_id"
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_20_091606) do
 
   create_table "tasks", force: :cascade do |t|
     t.string "title", limit: 50, null: false
-    t.integer "estimated_time_in_second", null: false
+    t.integer "estimated_time_in_second", default: 60, null: false
     t.bigint "routine_id"
     t.integer "position"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## 概要
- タスク編集フォームを作成する
- DBのroutinesテーブル、tasksテーブルの一部カラムに初期値を設定する
- tasksコントローラのparams_time_to_secondメソッド内容をサーバログにエラーが出力されないよう変更する
## やったこと
- ルーティン詳細画面にタスク編集フォームがモーダル表示される機能を実装する
- routines/_task_form.html.erbがタスク情報作成と更新の両方を担えるように、form_withのurlオプションをnew_record?メソッドによって条件分岐させた
- tasksコントローラのparams_time_to_secondメソッドで不要なパラメータを削除する処理を追加した
- マイグレーションファイルをロールバック後に変更し、routinesテーブルの以下のカラムに初期値を追加する
  - start_time
  - copied_count
  - completed_count
- マイグレーションファイルをロールバック後に変更し、tasksテーブルの以下のカラムに初期値を追加する
  - estimated_time_in_second
- routinesテーブルのcompleted_count、copied_countカラムに初期位置を追加したことで不要になったルーティン作成formのhidden_fieldを削除する


## 注意点
- routines/_task.html.erbをレンダリングする際はtask, routineの２種類の変数が必要
- tasksコントローラのアクションへのルーティングをshallow: trueに変更した

## 変更結果
<img src="https://i.gyazo.com/7801fb687536b96753fa0fddc6de4907.png">

## Issue 
closes #54 