### PR TITLE
タスクの並べ替えを行うコントローラを作成

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -21,7 +21,7 @@ class RoutinesController < ApplicationController
 
   def show
     @task = Task.new
-    @tasks = @routine.tasks
+    @tasks = @routine.tasks.order(position: :asc)
   end
 
   def edit; end

--- a/app/controllers/tasks/move_highers_controller.rb
+++ b/app/controllers/tasks/move_highers_controller.rb
@@ -1,0 +1,8 @@
+class Tasks::MoveHighersController < ApplicationController
+  def update
+    task = Task.find(params[:task_id])
+    task.move_heigher
+    routine = task.routine
+    redirect_to routine_path(routine)
+  end
+end

--- a/app/controllers/tasks/move_lowers_controller.rb
+++ b/app/controllers/tasks/move_lowers_controller.rb
@@ -1,0 +1,8 @@
+class Tasks::MoveLowersController < ApplicationController
+  def update
+    task = Task.find(params[:task_id])
+    task.move_lower
+    routine = task.routine
+    redirect_to routine_path(routine)
+  end
+end

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -22,7 +22,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <%= render partial: "task", collection: routine.tasks, locals: { routine: routine } %>
+      <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
     </div>
   </details>
 

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -37,7 +37,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <%= render partial: "task", collection: routine.tasks, locals: { routine: routine } %>
+      <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
     </div>
   </details>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,9 @@ Rails.application.routes.draw do
   namespace :routines do
     resources :actives, only: %i[ update ], param: :routine_id
   end
+
+  namespace :tasks do
+    resources :move_heighers, only: %i[ update ], param: :task_id
+    resources :move_lowers, only: %i[ update ], param: :task_id
+  end
 end


### PR DESCRIPTION
## 概要
- タスクのpositionカラムの値を操作して並べ替えを行うためのコントローラを作成する
- タスク一覧が表示されるページで、タスクがpositionカラムの値を元に昇順で表示されるようにする
## やったこと
- app/controllers/tasks/move_highers_controller.rbを作成する
- app/controllers/tasks/move_lowers_controller.rbを作成する
- 上記のコントローラにupdateアクションを追加する
- ルーティングを追加する
- タスクが表示される以下のページでタスク一覧がpositionカラムの値に対して昇順で並ぶように設定する
  - マイページ
  - ルーティン一覧画面
  - ルーティン詳細画面
## Issue
closes #56 