### PR TITLE
タスク並べ替えボタンを実装

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -13,7 +13,7 @@ class RoutinesController < ApplicationController
     @routine = current_user.routines.new(routine_params)
     if @routine.save
       flash[:notice] = "新しくルーティンを作成しました"
-      redirect_to root_path
+      redirect_to routines_path
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/tasks/move_highers_controller.rb
+++ b/app/controllers/tasks/move_highers_controller.rb
@@ -1,7 +1,7 @@
 class Tasks::MoveHighersController < ApplicationController
   def update
     task = Task.find(params[:task_id])
-    task.move_heigher
+    task.move_higher
     routine = task.routine
     redirect_to routine_path(routine)
   end

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -17,14 +17,14 @@
     </div>
   </div>
   <div class="flex">
-    <p class="mr-3">目安時間：</p>
-    <p class="mx-2">
+    <p class="mr-1.5">目安時間：</p>
+    <p class="mx-1.5">
       <%= task.estimated_time[:hour] %> h
     </p>
-    <p class="mx-2">
+    <p class="mx-1.5">
       <%= task.estimated_time[:minute] %> m
     </p>
-    <p class="mx-2">
+    <p class="mx-1.5">
       <%= task.estimated_time[:second] %> s
     </p>
   </div>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -17,18 +17,22 @@
       <%= link_to "削除", "#", class: "btn btn-outline text-red-300 btn-sm" %>
     </div>
   </div>
-
-  <div class="flex">
-    <p class="mr-3">目安時間：</p>
-    <p class="mx-2">
-      <%= task.estimated_time[:hour] %> h
-    </p>
-    <p class="mx-2">
-      <%= task.estimated_time[:minute] %> m
-    </p>
-    <p class="mx-2">
-      <%= task.estimated_time[:second] %> s
-    </p>
+  <div class="flex justify-between">
+    <div class="flex">
+      <p class="mr-1.5">目安時間：</p>
+      <p class="mx-1.5">
+        <%= task.estimated_time[:hour] %> h
+      </p>
+      <p class="mx-1.5">
+        <%= task.estimated_time[:minute] %> m
+      </p>
+      <p class="mx-1.5">
+        <%= task.estimated_time[:second] %> s
+      </p>
+    </div>
+    <span>
+      <%= link_to "↑", tasks_move_higher_path(task), data: { turbo_method: :patch }, class:"btn btn-outline text-blue-200 btn-sm mr-3" %>
+      <%= link_to "↓", tasks_move_lower_path(task), data: { turbo_method: :patch }, class:"btn btn-outline text-blue-200 btn-sm mr-3" %>
+    </span>
   </div>
-
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
 
   namespace :tasks do
-    resources :move_heighers, only: %i[ update ], param: :task_id
+    resources :move_highers, only: %i[ update ], param: :task_id
     resources :move_lowers, only: %i[ update ], param: :task_id
   end
 end


### PR DESCRIPTION
## 概要
タスク並べ替え機能を実装するために、タスクの順番を操作するボタンを追加する
## やったこと
- ルーティン作成後、ルーティン一覧画面に遷移するように修正する
- タスクの順番を1つ上に上げるボタンと1つ下に下げるボタンを以下の画面に設置する
  - ルーティン一覧画面
  - ルーティン詳細画面
## 変更結果
<img src="https://i.gyazo.com/1b55b37112a5b8af3c1bd0144e3f0a6f.png">
## Issue
closes #57 