### PR TITLE
ルーティン投稿処理を行うコントローラを作成する

### DIFF
--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -1,0 +1,16 @@
+class Routines::PostsController < ApplicationController
+  def index
+    @routines = Routine.includes(:tasks).posted
+  end
+
+  def update
+    routine = current_user.routines.find(params[:routine_id])
+    if routine.is_posted?
+      routine.update!(is_posted: false)
+      redirect_to routines_path, notice: "ルーティンを非公開にしました"
+    else
+      routine.update!(is_posted: true)
+      redirect_to routines_path, notice: "ルーティンを投稿しました"
+    end
+  end
+end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -4,4 +4,6 @@ class Routine < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 500 }
+
+  scope :posted, -> { where(is_posted: true) }
 end

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -22,9 +22,9 @@
   <div class="flex justify-end mb-5">
     <div class="flex">
       <% if routine.is_posted? %>
-        <%= link_to "投稿済み", "#", class: "btn btn-outline btn-default btn-md mx-3" %>
+        <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn btn-outline btn-default btn-md mx-3" %>
       <% else %>
-        <%= link_to "投稿する", "#", class: "btn btn-outline btn-info btn-md mx-3" %>
+        <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn btn-outline btn-info btn-md mx-3" %>
       <% end %>
 
       <% if routine.is_active? %>

--- a/app/views/routines/posts/index.html.erb
+++ b/app/views/routines/posts/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Routines::Posts#index</h1>
+<p>Find me in app/views/routines/posts/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   namespace :routines do
     resources :actives, only: %i[ update ], param: :routine_id
+    resources :posts, only: %i[ index update ], param: :routine_id
   end
 
   namespace :tasks do


### PR DESCRIPTION
## 概要
ルーティン投稿機能を実装するため、ルーティン投稿処理を行うコントローラを作成する
## やったこと
- app/controllers/routines/posts_controller.rbを作成する
- index, updateアクションを追加する
- ルーティングを追加する
- ルーティン一覧画面から遷移する
## 注意点
- 投稿されたルーティンを投稿日順に並べるために、ルーティンを投稿した日時を保存するカラムをroutinesテーブルに指定する必要がある
## 変更結果
<img src="https://i.gyazo.com/fb5f2f2a372a145ea838c11915e7b5d5.png">
## Issue
closes #61 