### PR TITLE
投稿一覧機能の実装 + URLの修正

### DIFF
--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -1,6 +1,6 @@
 class Routines::PostsController < ApplicationController
   def index
-    @routines = Routine.includes(:tasks).posted
+    @routines = Routine.includes(:tasks, :user).posted
   end
 
   def update

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -13,10 +13,10 @@
     <p><%= routine.description %></p>
   </div>
   
-  <div class="mb-5 items-center">
-    <p>開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
-    <p>目安達成時間:</p>
-    <p>達成回数： <%= routine.completed_count %></p>
+  <div class="mb-5 items-center flex">
+    <p class="mr-5 p-2 bg-gray-100">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+    <p class="mr-5 p-2 bg-gray-100">目安達成時間:</p>
+    <p class="mr-5 p-2 bg-gray-100">達成回数： <%= routine.completed_count %></p>
   </div>
 
   <div class="flex justify-end mb-5">
@@ -37,7 +37,7 @@
   <details class="collapse bg-white">
     <summary class="collapse-title font-medium">タスク一覧</summary>
     <div class="collapse-content">
-      <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
+      <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
     </div>
   </details>
 

--- a/app/views/routines/posts/_posted_routine.html.erb
+++ b/app/views/routines/posts/_posted_routine.html.erb
@@ -9,8 +9,9 @@
     </div>
   </div>
 
-  <div class="mb-5 text-center">
-    <p class="bg-green-100 w-1/4 mr-3 mx-auto">コピー数： <%= routine.copied_count %></p>
+  <div class="mb-5 flex justify-end">
+    <p class="bg-green-100 p-2 mx-3">投稿者： <%= routine.user.name %></p>
+    <p class="bg-green-100 p-2 mx-3">コピー数： <%= routine.copied_count %></p>
   </div>
   
 

--- a/app/views/routines/posts/_posted_routine.html.erb
+++ b/app/views/routines/posts/_posted_routine.html.erb
@@ -1,0 +1,33 @@
+<div class="border border-amber-300 p-3 w-1/2 my-5 mx-auto bg-sky-100 bg-opacity-50">
+
+  <div class="flex justify-between items-center mb-5 mx-3">
+    <h1 class="text-3xl border-b border-cyan-300"><%= routine.title %></h1>
+    <div class="flex">
+      <%= link_to "コピー", "#", class: "btn btn-outline btn-success btn-md mr-3" %>
+      <%= link_to "お気に入り", "#", class: "btn btn-outline btn-info btn-md mr-3" %>
+      <%= link_to "いいね", "#", class: "btn btn-outline btn-error btn-md" %>
+    </div>
+  </div>
+
+  <div class="mb-5 text-center">
+    <p class="bg-green-100 w-1/4 mr-3 mx-auto">コピー数： <%= routine.copied_count %></p>
+  </div>
+  
+
+  <div class="mb-5 bg-white p-5">
+    <p><%= routine.description %></p>
+  </div>
+  
+  <div class="mb-5 items-center flex">
+    <p class="mr-5 p-2 bg-gray-100">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+    <p class="mr-5 p-2 bg-gray-100">目安達成時間:</p>
+  </div>
+
+  <details class="collapse bg-white">
+    <summary class="collapse-title font-medium">タスク一覧</summary>
+    <div class="collapse-content">
+      <%= render partial: "routines/posts/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
+    </div>
+  </details>
+
+</div>

--- a/app/views/routines/posts/_task.html.erb
+++ b/app/views/routines/posts/_task.html.erb
@@ -1,0 +1,17 @@
+<div class="border border-green-300 p-2 mb-3">
+  <h1 class="text-xl border-b border-cyan-300 mb-5"><%= task.title %></h1>
+
+  <div class="flex">
+    <p class="mr-1.5">目安時間：</p>
+    <p class="mx-1.5">
+      <%= task.estimated_time[:hour] %> h
+    </p>
+    <p class="mx-1.5">
+      <%= task.estimated_time[:minute] %> m
+    </p>
+    <p class="mx-1.5">
+      <%= task.estimated_time[:second] %> s
+    </p>
+  </div>
+
+</div>

--- a/app/views/routines/posts/index.html.erb
+++ b/app/views/routines/posts/index.html.erb
@@ -1,2 +1,8 @@
-<h1>Routines::Posts#index</h1>
-<p>Find me in app/views/routines/posts/index.html.erb</p>
+<div class="mt-5">
+  <%= link_to "ルーティンを投稿する", routines_path, class:"btn btn-outline btn-success btn-md right-10 absolute " %>
+  <% if @routines.empty? %>
+    <p class="text-center">現在、投稿はありません</p>
+  <% else %>
+    <%= render partial: "routines/posts/posted_routine", collection: @routines, as: :routine %>
+  <% end %>
+</div>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -13,9 +13,9 @@
     <p><%= @routine.description %></p>
   </div>
   <div class="flex my-5">
-    <p class="mr-5">開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
-    <p class="mr-5">目安達成時間:</p>
-    <p class="mr-5">達成回数： <%= @routine.completed_count %></p>
+    <p class="mr-5 p-2 bg-gray-100">開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
+    <p class="mr-5 p-2 bg-gray-100">目安達成時間:</p>
+    <p class="mr-5 p-2 bg-gray-100">達成回数： <%= @routine.completed_count %></p>
   </div>
 
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
             <%= link_to "ルーティンを作成する", new_routine_path, class:"text-center p-3 mb-2" %>
           </li>
           <li>
-            <%= link_to "投稿一覧を見る", "#", class:"text-center p-3 mb-2" %>
+            <%= link_to "投稿一覧を見る", routines_posts_path, class:"text-center p-3 mb-2" %>
           </li>
           <li>
             <%= link_to "マイページへ", "#", class:"text-center p-3 mb-2" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :tasks, only: %i[ create update destroy ], shallow: true
   end
 
-  namespace :routines do
+  namespace :routines, path: 'routine' do
     resources :actives, only: %i[ update ], param: :routine_id
     resources :posts, only: %i[ index update ], param: :routine_id
   end


### PR DESCRIPTION
## 概要
- 投稿されたルーティン一覧を表示するViewを作成する
- URLが競合して不具合が発生しないように、ルーティングを修正する
## 問題点
- config/routes.rbファイルで、resources :postsを namespace :routinesブロック内に設置していた。しかしこのままでは、resources :routinesで定義したルーティンリソースへのURLとroutines/postsコントローラへのURLが競合してしまい挙動が予期したものにならない。（例：routines/postsコントローラのindexアクションへのURLは"routines/posts"となるが、これはroutinesコントローラのshowアクションのURL(routines/:id)として扱われてしまう）
## やったこと（修正）
- namespaceのpathオプションで path: 'routine'とすることで Routines::PostsコントローラのURLを"routine/posts"のように変更する

## やったこと（機能の実装）
- 投稿されたルーティン情報をを表示する app/views/routines/posts/index.html.erbを作成する
- ヘッダーから遷移する
- ルーティン情報を表示するViewの以下の部分を修正する
  - 開始時間、目安達成時間、達成回数の表示を横並びにする
 
## 変更結果
<img src="https://i.gyazo.com/f024dbcc1dae2f40f8a0272356588aa5.png">

## Issue
closes #62 
