### PR TITLE
投稿されたルーティンをコピーする機能を実装

### DIFF
--- a/app/controllers/routines/copies_controller.rb
+++ b/app/controllers/routines/copies_controller.rb
@@ -1,0 +1,33 @@
+class Routines::CopiesController < ApplicationController
+  def create
+    # コピーされた数を+1する
+    routine_origin = Routine.includes(:tasks).find(params[:routine_id])
+    copy_counting(routine_origin)
+    # ルーティン内容をコピーする
+    routine_dup = copy_routine(routine_origin)
+    # タスクをコピーする
+    copy_tasks(routine_origin, routine_dup)
+
+    flash[:notice] = "コピーしました。（#{routine_origin.title}）"
+    redirect_to routines_posts_path
+  end
+
+  private
+
+  def copy_counting(routine_origin)
+    routine_origin.copied_count += 1
+    routine_origin.save!
+  end
+
+  def copy_routine(routine_origin)
+    routine_dup = routine_origin.dup.reset_status
+    routine_dup.update!(user_id: current_user.id)
+    return routine_dup
+  end
+
+  def copy_tasks(routine_origin, routine_dup)
+    routine_origin.tasks.each do |task|
+      task_dup = task.dup.update!(routine_id: routine_dup.id)
+    end
+  end
+end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -6,4 +6,13 @@ class Routine < ApplicationRecord
   validates :description, length: { maximum: 500 }
 
   scope :posted, -> { where(is_posted: true) }
+
+  
+  def reset_status
+    self.is_active = false
+    self.is_posted = false
+    self.copied_count = 0
+    self.completed_count = 0
+    return self
+  end
 end

--- a/app/views/routines/posts/_posted_routine.html.erb
+++ b/app/views/routines/posts/_posted_routine.html.erb
@@ -3,7 +3,7 @@
   <div class="flex justify-between items-center mb-5 mx-3">
     <h1 class="text-3xl border-b border-cyan-300"><%= routine.title %></h1>
     <div class="flex">
-      <%= link_to "コピー", "#", class: "btn btn-outline btn-success btn-md mr-3" %>
+      <%= link_to "コピー", routine_copies_path(routine),data: { turbo_method: :post }, class: "btn btn-outline btn-success btn-md mr-3" %>
       <%= link_to "お気に入り", "#", class: "btn btn-outline btn-info btn-md mr-3" %>
       <%= link_to "いいね", "#", class: "btn btn-outline btn-error btn-md" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   resources :routines do
     resources :tasks, only: %i[ create update destroy ], shallow: true
+    resources :copies, only: %i[ create ], module: :routines
   end
 
   namespace :routines, path: 'routine' do


### PR DESCRIPTION
## 概要
投稿されたルーティンをコピーする機能を実装するため、コントローラを作成する
## やったこと
- app/controllers/routines/copies_controller.rbを作成する
- ルーティンの内容とタスクをコピーするcreateアクションを作成する
- ルーティングを追加する
## 変更結果
<img src="https://i.gyazo.com/fde65f39f942f322e1a57a6c34d8c181.png">
## Issue
closes #64 