### PR TITLE
実践中ルーティンのタスク遂行画面を表示する処理を行うコントローラを作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  before_action :playing_task_sesison_reset
 
   private
 
   def not_authenticated
     flash[:alert] = 'ログインしてください'
     redirect_to login_path
+  end
+
+  def playing_task_sesison_reset
+    session[:playing_task_num] = nil if session[:playing_task_num]
   end
 end

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -1,0 +1,41 @@
+class Routines::PlaysController < ApplicationController
+  before_action :block_if_no_session, only: %i[ show update ]
+  before_action :set_routine
+  before_action :arrange_tasks_by_position, only: %i[ show update ]
+  skip_before_action :playing_task_sesison_reset
+
+  def create
+    session[:playing_task_num] = 0
+    redirect_to play_path(@routine)
+  end
+
+  def show
+    @task = @tasks[ session[:playing_task_num] ]
+  end
+
+  def update
+    session[:playing_task_num] += 1
+    if session[:playing_task_num] >= @tasks.count
+      @routine.completed_count += 1
+      @routine.save!
+      redirect_to root_path, alert: "本当は違うページに遷移するンダゼェぇぇぇぇぇl"
+    else
+      redirect_to play_path(@routine)
+    end
+  end
+
+  private
+
+  def set_routine
+    @routine = current_user.routines.find(params[:routine_id])
+  end
+
+  def arrange_tasks_by_position
+    @tasks = @routine.tasks.order(position: :asc)
+  end
+
+  # createアクションを介さないアクセスを拒否
+  def block_if_no_session
+    redirect_to root_path, alert: "ページに遷移できませんでした" if session[:playing_task_num].nil?
+  end
+end

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -16,7 +16,7 @@
 
   <div class="text-center mb-5">
     <div class="text-center">
-        <%= link_to "スタート", "#", class: "btn bg-green-400 btn-lg mx-3" %>
+        <%= link_to "スタート", routine_plays_path(routine), data: { turbo_method: :post }, class: "btn bg-green-400 btn-lg mx-3" %>
     </div>
   </div>
   <details class="collapse bg-white">

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -1,0 +1,2 @@
+<%= @task.title %>
+<%= link_to "next", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-accent" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,13 @@ Rails.application.routes.draw do
   resources :routines do
     resources :tasks, only: %i[ create update destroy ], shallow: true
     resources :copies, only: %i[ create ], module: :routines
+    resources :plays, only: %i[ create update show ], param: :routine_id, module: :routines, shallow: true
   end
 
   namespace :routines, path: 'routine' do
     resources :actives, only: %i[ update ], param: :routine_id
     resources :posts, only: %i[ index update ], param: :routine_id
+    
   end
 
   namespace :tasks do


### PR DESCRIPTION
## 概要
タスク遂行機能を実装するため、タスク遂行画面を表示する処理を行うコントローラを作成する
## やったこと
- app/controllers/routines/plays_controller.rbを作成する
- create, show, updateアクションを作成する
- ルーティングを追加する
- セッションが発行されていない場合、show, updateアクションにアクセスできないようにbefore_actionを設定する
- 他のページに遷移すると、session[:playing_task_num]の値が削除されるように設定する
- マイページのスタートボタンから、createアクションに遷移する
## Issue
closes #65 