### PR TITLE
カウントダウン機能を実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./routines_plays"

--- a/app/javascript/routines_plays.js
+++ b/app/javascript/routines_plays.js
@@ -1,0 +1,74 @@
+document.addEventListener("turbo:load", function(event) {
+  if (!document.querySelector("#countdown-zone")) return;
+
+  let hourElement = document.querySelector("#hour");
+  let minuteElement = document.querySelector("#minute");
+  let secondElement = document.querySelector("#second");
+
+  let hour = Number(hourElement.textContent);
+  let minute = Number(minuteElement.textContent);
+  let second = Number(secondElement.textContent);
+
+  function countdownHour() {
+    switch (hour) {
+      case 0:
+        console.log("カウントダウン終了");
+        clearInterval(setIntervalId);
+        break;
+      default:
+        hour = hour - 1;
+        if (hour < 10) {
+          hourElement.textContent = `0${hour}`;
+        } else {
+          hourElement.textContent = hour;
+        }
+        minute = 59;
+        minuteElement.textContent = minute;
+        second = 59;
+        secondElement.textContent = second;
+        break;
+    }
+  }
+
+    function countdownMinute() {
+      switch (minute) {
+        case 0:
+          countdownHour();
+          break;
+        default:
+          minute = minute - 1;
+          if (minute < 10) {
+            minuteElement.textContent = `0${minute}`;
+          } else {
+            minuteElement.textContent = minute;
+          }
+          second = 59;
+          secondElement.textContent = second;
+          break;
+      }
+    }
+
+    function countdown() {
+      switch (second) {
+        case 0:
+          countdownMinute();
+          break;
+        default:
+          second = second - 1;
+          if (second < 10) {
+            secondElement.textContent = `0${second}`;
+          } else {
+            secondElement.textContent = second;
+          }
+          break;
+      }
+    }
+
+    // 1秒ごとにカウントダウンを実行
+    const setIntervalId = setInterval(countdown, 1000);
+
+    // ページを離れる前にカウントダウン処理を終了する
+    document.addEventListener("turbo:before-visit", function() {
+      clearInterval(setIntervalId);
+    });
+});

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,15 +6,21 @@ class Task < ApplicationRecord
   validates :estimated_time_in_second, presence: true
 
   def estimated_time
-    result = Hash.new
-    value = estimated_time_in_second
-
-    result[:hour] = value / 3600
-    value -= result[:hour] * 3600
-    result[:minute] = value / 60
-    value -= result[:minute] * 60
-    result[:second] = value
-
+    result = second_to_time_string(estimated_time_in_second)
+    result[:hour] = "0#{result[:hour]}" if result[:hour] < 10
+    result[:minute] = "0#{result[:minute]}" if result[:minute] < 10
+    result[:second] = "0#{result[:second]}" if result[:second] < 10
     return result
+  end
+
+  private
+
+  def second_to_time_string(time_in_second)
+    hour = time_in_second / 3600
+    time_in_second -= hour * 3600
+    minute = time_in_second / 60
+    time_in_second -= minute * 60
+    second = time_in_second
+    { hour: hour, minute: minute, second: second }
   end
 end

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -10,11 +10,11 @@
     <%= @task.title %>
   </h1>
 
-  <p class="text-2xl my-10 bg-white rounded-full w-1/2 mx-auto p-3">
-    <span class="text-3xl mr-3"><%= @task.estimated_time[:hour] %>h</span>
-    <span class="text-3xl mr-3"><%= @task.estimated_time[:minute] %>m</span>
-    <span class="text-3xl mr-3"><%= @task.estimated_time[:second] %>s</span>
-  </p>
+  <div class="text-2xl my-10 bg-white rounded-full w-1/2 mx-auto p-3 flex justify-center">
+    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:hour] %></span>h</p>
+    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:minute] %></span>m</p>
+    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:second] %></span>s</p>
+  </div>
   
   <%= link_to "達成", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-lg bg-green-200 my-10 mx-3" %>
   <%= link_to "スキップ", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-lg bg-green-200 my-10 mx-3" %>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -10,10 +10,10 @@
     <%= @task.title %>
   </h1>
 
-  <div class="text-2xl my-10 bg-white rounded-full w-1/2 mx-auto p-3 flex justify-center">
-    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:hour] %></span>h</p>
-    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:minute] %></span>m</p>
-    <p class="text-3xl mr-3"><span><%= @task.estimated_time[:second] %></span>s</p>
+  <div id="countdown-zone" class="text-2xl my-10 bg-white rounded-full w-1/2 mx-auto p-3 flex justify-center">
+    <p class="text-3xl mr-3"><span id="hour"><%= @task.estimated_time[:hour] %></span>h</p>
+    <p class="text-3xl mr-3"><span id="minute"><%= @task.estimated_time[:minute] %></span>m</p>
+    <p class="text-3xl mr-3"><span id="second"><%= @task.estimated_time[:second] %></span>s</p>
   </div>
   
   <%= link_to "達成", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-lg bg-green-200 my-10 mx-3" %>


### PR DESCRIPTION
## 概要
タスク遂行画面に表示された目安時間が1秒ごとにカウントダウンする機能を実装する
## やったこと
- app/javascript/routines_plays.jsを作成する
- taskモデルのestimeted_timeメソッドについて、返り値として2桁表示の時刻を返すように修正する
- taskモデルのestimated_timeメソッドの処理をわかりやすく修正する
- タスク遂行画面の目安時間表示部分にIDを追加する
## 変更結果
<img src="https://i.gyazo.com/873d0b902e588875cc8f01d65c25566e.gif" width="320">
## Issue
closes #71