### PR TITLE
ルーティンの投稿日を保存するカラムを追加

### DIFF
--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -1,6 +1,6 @@
 class Routines::PostsController < ApplicationController
   def index
-    @routines = Routine.includes(:tasks, :user).posted
+    @routines = Routine.includes(:tasks, :user).posted.order(posted_at: :desc)
   end
 
   def update
@@ -9,7 +9,7 @@ class Routines::PostsController < ApplicationController
       routine.update!(is_posted: false)
       redirect_to routines_path, notice: "ルーティンを非公開にしました"
     else
-      routine.update!(is_posted: true)
+      routine.update!(is_posted: true, posted_at: Time.current)
       redirect_to routines_path, notice: "ルーティンを投稿しました"
     end
   end

--- a/db/migrate/20240824074112_add_column_to_routines.rb
+++ b/db/migrate/20240824074112_add_column_to_routines.rb
@@ -1,0 +1,5 @@
+class AddColumnToRoutines < ActiveRecord::Migration[7.0]
+  def change
+    add_column :routines, :posted_at, :datetime 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_20_091606) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_24_074112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_20_091606) do
     t.integer "copied_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "posted_at"
     t.index ["user_id"], name: "index_routines_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
DBのRoutinesテーブルに投稿した日を保存するカラムを作成する
## やったこと
- db/migrate/20240824074112_add_column_to_routines.rbを作成し、posted_atカラムをroutinesテーブルに追加する
- 投稿ルーティン一覧で投稿が投稿日順に表示されるようにする
## 注意点
- Heroku側でもmigrationファイルを適応しないといけない
## Issue
closes #123 