### PR TITLE
フォームのデザイン調整

### DIFF
--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -2,8 +2,8 @@
 
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end sm:order-last sm:ml-auto">
-      <%= link_to "編集", edit_routine_path(routine), class: "btn bg-green-300 btn-sm text-xs mr-3 sm:btn-md sm:text-sm sm:mr-5 md:text-base lg:text-lg lg:btn-lg" %>
-      <%= link_to "詳細", routine_path(routine), class: "btn bg-blue-200 btn-sm text-xs sm:btn-md sm:text-sm md:text-base lg:text-lg lg:btn-lg" %>
+      <%= link_to "編集", edit_routine_path(routine), class: "btn bg-green-300 btn-md text-sm mr-3 sm:mr-5 md:text-base lg:text-lg lg:btn-lg" %>
+      <%= link_to "詳細", routine_path(routine), class: "btn bg-blue-200 btn-md text-sm md:text-base lg:text-lg lg:btn-lg" %>
     </div>
     <h1 class="break-words text-lg font-semibold border-b border-orange-200 my-2 sm:text-2xl md:text-3xl lg:text-4xl"><%= routine.title %></h1>
 
@@ -17,7 +17,7 @@
 
   <div class="text-center mb-5">
     <div class="text-center">
-        <%= link_to "スタート", routine_plays_path(routine), data: { turbo_method: :post }, class: "btn rounded-full bg-green-300 btn-md hover:bg-green-500 sm:btn-lg md:text-xl md:btn-wide lg:h-24 lg:text-2xl" %>
+        <%= link_to "スタート", routine_plays_path(routine), data: { turbo_method: :post }, class: "btn rounded-full bg-green-300 btn-md hover:bg-green-500 min-w-32 sm:btn-lg md:text-xl md:btn-wide lg:h-24 lg:text-2xl" %>
     </div>
   </div>
   <details class="collapse bg-emerald-100 border border-green-200 items-center text-sm sm:text-base lg:text-lg">

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -2,8 +2,8 @@
 
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end sm:order-last sm:ml-auto">
-      <%= link_to "編集", edit_routine_path(routine), class: "btn bg-green-300 btn-md text-sm mr-3 sm:mr-5 md:text-base lg:text-lg lg:btn-lg" %>
-      <%= link_to "詳細", routine_path(routine), class: "btn bg-blue-200 btn-md text-sm md:text-base lg:text-lg lg:btn-lg" %>
+      <%= link_to "編集", edit_routine_path(routine), class: "btn bg-gradient-to-tl from-green-300 to-green-100 btn-md text-sm mr-3 sm:mr-5 md:text-base lg:text-lg lg:btn-lg" %>
+      <%= link_to "詳細", routine_path(routine), class: "btn  bg-gradient-to-tl from-blue-300 to-blue-100 btn-md text-sm md:text-base lg:text-lg lg:btn-lg" %>
     </div>
     <h1 class="break-words text-lg font-semibold border-b border-orange-200 my-2 sm:text-2xl md:text-3xl lg:text-4xl"><%= routine.title %></h1>
 
@@ -17,10 +17,10 @@
 
   <div class="text-center mb-5">
     <div class="text-center">
-        <%= link_to "スタート", routine_plays_path(routine), data: { turbo_method: :post }, class: "btn rounded-full bg-green-300 btn-md hover:bg-green-500 min-w-32 sm:btn-lg md:text-xl md:btn-wide lg:h-24 lg:text-2xl" %>
+        <%= link_to "スタート", routine_plays_path(routine), data: { turbo_method: :post }, class: "btn rounded-full  bg-gradient-to-tl from-green-400 to-emerald-100 btn-md hover:bg-green-500 min-w-32 sm:btn-lg md:text-xl md:btn-wide lg:h-24 lg:text-2xl" %>
     </div>
   </div>
-  <details class="collapse bg-emerald-100 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
+  <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
     <div class="collapse-content">
       <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-5 mx-3">
     <h1 class="text-sm border-b border-cyan-300 font-semibold sm:text-base md:text-lg lg:text-xl"><%= task.title %></h1>
     <div class="">
-      <button class="btn bg-green-400 btn-sm text-xs sm:btn-md sm:text-sm md:text-base lg:btn-lg lg:text-lg" onclick="document.querySelector('#edit_task_form_in_mypage_<%= task.id %>').showModal()">編集</button>
+      <button class="btn bg-green-300 btn-md text-sm md:text-base lg:btn-lg lg:text-lg" onclick="document.querySelector('#edit_task_form_in_mypage_<%= task.id %>').showModal()">編集</button>
       <dialog id="edit_task_form_in_mypage_<%= task.id %>" class="modal mx-auto">
         <div class="modal-box">
           <h1 class="text-center text-lg font-semibold mb-5 sm:text-xl md:text-2xl lg:text-3xl md:mb-10">タスク編集</h1>

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-5 mx-3">
     <h1 class="text-sm border-b border-cyan-300 font-semibold sm:text-base md:text-lg lg:text-xl"><%= task.title %></h1>
     <div class="">
-      <button class="btn bg-green-300 btn-md text-sm md:text-base lg:btn-lg lg:text-lg" onclick="document.querySelector('#edit_task_form_in_mypage_<%= task.id %>').showModal()">編集</button>
+      <button class="btn bg-gradient-to-tl from-green-300 to-green-100 border border-green-400 btn-md text-sm md:text-base lg:btn-lg lg:text-lg" onclick="document.querySelector('#edit_task_form_in_mypage_<%= task.id %>').showModal()">編集</button>
       <dialog id="edit_task_form_in_mypage_<%= task.id %>" class="modal mx-auto">
         <div class="modal-box">
           <h1 class="text-center text-lg font-semibold mb-5 sm:text-xl md:text-2xl lg:text-3xl md:mb-10">タスク編集</h1>

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -9,7 +9,7 @@
           <%= render partial: "routines/task_form", locals: { task: task, routine: routine } %>
           <div class="modal-action">
             <form method="dialog">
-              <button class="btn btn-sm bg-gray-200 text-sm border sm:btn-md sm:text-base md:min-h-16 lg:text-lg lg:btn-lg">キャンセル</button>
+              <button class="btn btn-sm bg-gray-200 text-sm border min-h-12 sm:btn-md sm:text-base md:min-h-16 lg:text-lg lg:btn-lg">キャンセル</button>
             </form>
           </div>
         </div>

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -2,8 +2,8 @@
   <h1 class="text-center text-xl py-5 sm:text-2xl md:text-3xl lg:text-4xl xl:test-5xl">おはようございます！</h1>
 </div>
 <div class="flex justify-center gap-2 sm:gap-4 md:gap-8">
-  <%= link_to "ルーティン作成", new_routine_path, class:"btn bg-cyan-200 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 lg:text-lg lg:btn-lg lg:w-44" %>
-  <%= link_to "ルーティン一覧", routines_path, class:"btn bg-cyan-200 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 lg:text-lg lg:btn-lg lg:w-44" %>
+  <%= link_to "ルーティン作成", new_routine_path, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 lg:text-lg lg:btn-lg lg:w-44" %>
+  <%= link_to "ルーティン一覧", routines_path, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 lg:text-lg lg:btn-lg lg:w-44" %>
 </div>
 
 <div class="my-3">
@@ -11,7 +11,7 @@
     <%= render "routine", routine: @routine %>
   <% else %>
     <div class="text-center items-center">
-      <%= link_to routines_path, class:"items-center btn bg-yellow-400 min-h-10 sm:btn-md lg:btn-lg" do %>
+      <%= link_to routines_path, class:"items-center btn bg-gradient-to-tl from-amber-300 to-yellow-100 min-h-10 sm:btn-md lg:btn-lg" do %>
         <p class="text-md sm:text-lg lg:text-xl">ルーティンを実践中にしましょう！！</p>
       <% end %>
     </div>

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -1,21 +1,15 @@
 <%= form_with model: routine, class:"text-center" do |f| %>
   <div class="mx-auto my-8">
-    <%= f.label :title, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.text_field :title, class:"grow", placeholder: "タイトルを入力してください" %>
-    <% end %>
+    <%= f.text_field :title, class:"input input-bordered w-10/12 sm:text-lg lg:w-8/12 lg:min-h-16", placeholder: "タイトルを入力してください" %>
   </div>
 
   <div class="mx-auto my-8">
-    <%= f.label :description, class: "mx-auto flex items-center gap-2 textarea textarea-bordered w-1/3" do %>
-      <%= f.text_area :description, class:"grow", placeholder: "説明文を入力してください" %>
-    <% end %>
+    <%= f.text_area :description, class:"textarea textarea-bordered w-10/12 min-h-10 sm:text-lg sm:min-h-32 lg:w-8/12", placeholder: "説明文を入力してください" %>
   </div>
 
   <div class="mx-auto my-8">
-    <%= f.label :start_time, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.time_field :start_time, class:"grow", min: "00:00", max: "23:59" %>
-    <% end %>
+    <%= f.time_field :start_time, class:"input input-bordered w-8/12 text-lg text-center md:min-h-16 md:text-xl", min: "00:00", max: "23:59" %>
   </div>
 
-  <%= f.submit nil, class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+  <%= f.submit nil, class:"btn bg-cyan-200 mb-5 w-6/12 text-base btn-md sm:btn-lg sm:text-lg lg:text-xl" %>
 <% end %>

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -11,5 +11,5 @@
     <%= f.time_field :start_time, class:"input input-bordered w-8/12 text-lg text-center md:min-h-16 md:text-xl", min: "00:00", max: "23:59" %>
   </div>
 
-  <%= f.submit nil, class:"btn bg-cyan-200 mb-5 w-6/12 text-base btn-md sm:btn-lg sm:text-lg lg:text-xl" %>
+  <%= f.submit nil, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 mb-5 w-6/12 text-base btn-md sm:btn-lg sm:text-lg lg:text-xl" %>
 <% end %>

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -15,5 +15,5 @@
     </div>
   </div>
 
-  <%= f.submit "保存", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 mx-auto sm:btn-lg sm:text-lg lg:min-w-64 lg-text-xl" %>
+  <%= f.submit "保存", class:"btn bg-gradient-to-tl from-green-300 to-green-100 mb-5 btn-md min-w-28 mx-auto sm:btn-lg sm:text-lg lg:min-w-64 lg-text-xl" %>
 <% end %>

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -1,18 +1,19 @@
-<%= form_with model: task, url: task.new_record? ? routine_tasks_path(routine) : task_path(task), class:"text-center" do |f| %>
-  <div class="mb-5">
-    <%= f.label :title, "タイトル" %> <br>
-    <%= f.text_field :title, class:"border w-1/2" %>
+<%= form_with model: task, url: task.new_record? ? routine_tasks_path(routine) : task_path(task), class: "text-center" do |f| %>
+  <div class="mb-5 md:mb-10">
+    <%= f.label :title, "タイトル:", class: "mb-2 font-medium text-lg sm:text-xl md:font-semibold" %><br>
+    <%= f.text_field :title, class:"min-h-10 w-10/12 p-2 mx-auto border border-gray-300 hover:border-gray-500 rounded-lg md:text-xl" %>
+  </div>
+  <div class="mb-5 md:mb-10">
+    <p class="mb-2 font-medium text-lg md:font-semibold">目安時間:</p>
+    <div class="flex justify-center items-center gap-2 mb-5 text-lg md:gap-4 md:text-xl">  
+      <%= f.number_field :hour, class: "w-2/11 border border-gray-300 rounded-lg min-h-6 p-0.5 sm:p-3 sm:4/12 hover:border-gray-500", min: 0, max: 23, value: task.estimated_time[:hour] %>
+      <span class="sm:text-xl">h</span>
+      <%= f.number_field :minute, class: "w-2/11 border border-gray-300 rounded-lg min-h-6 p-0.5 sm:p-3 sm:4/12 hover:border-gray-500", min: 0, max: 59, value: task.estimated_time[:minute] %>
+      <span class="sm:text-xl">m</span>
+      <%= f.number_field :second, class: "w-2/11 border border-gray-300 rounded-lg min-h-6 p-0.5 sm:p-3 sm:4/12 hover:border-gray-500", min: 0, max: 59, value: task.estimated_time[:second] %>
+      <span class="sm:text-xl">s</span>
+    </div>
   </div>
 
-  <p class="mb-1">目安時間:</p>
-  <div class="flex justify-center mb-5">  
-    <%= f.number_field :hour, class: "w-1/6 border", min: 0, max: 23, value: task.estimated_time[:hour] %>
-    <span class="px-2">h</span>
-    <%= f.number_field :minute, class: "w-1/6 border", min: 0, max: 59, value: task.estimated_time[:minute] %>
-    <span class="px-2">m</span>
-    <%= f.number_field :second, class: "w-1/6 border", min: 0, max: 59, value: task.estimated_time[:second] %>
-    <span class="px-2">s</span>
-  </div>
-
-  <%= f.submit "保存", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+  <%= f.submit "保存", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 mx-auto sm:btn-lg sm:text-lg lg:min-w-64 lg-text-xl" %>
 <% end %>

--- a/app/views/routines/edit.html.erb
+++ b/app/views/routines/edit.html.erb
@@ -2,5 +2,5 @@
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "戻る", routines_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %>
+  <%= link_to "戻る", routines_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %>
 </div>

--- a/app/views/routines/edit.html.erb
+++ b/app/views/routines/edit.html.erb
@@ -1,6 +1,6 @@
-<h1 class="text-3xl mt-5 mb-15 text-center">ルーティン編集</h1>
+<h1 class="text-lg mt-5 mb-5 text-center font-semibold sm:text-2xl md:text-3xl lg:text-4xl">ルーティン編集</h1>
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "戻る", routines_path, class: "btn btn-outline btn-info mx-auto" %>
+  <%= link_to "戻る", routines_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %>
 </div>

--- a/app/views/routines/edit.html.erb
+++ b/app/views/routines/edit.html.erb
@@ -2,5 +2,5 @@
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "戻る", routines_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %>
+  <%= link_to "戻る", routines_path, class: "btn bg-gradient-to-tl from-gray-300 to-gray-200 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %>
 </div>

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -2,6 +2,6 @@
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gradient-to-tl from-gray-300 to-gray-200 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
   <%= link_to "ルーティン一覧ページへ", routines_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-lg mt-5 mb-5 text-center sm:text-2xl md:text-3xl lg:text-4xl">ルーティン新規作成</h1>
+<h1 class="text-lg mt-5 mb-5 text-center font-semibold sm:text-2xl md:text-3xl lg:text-4xl">ルーティン新規作成</h1>
 
 <div class="text-center">
   <%= render "form", routine: @routine %>

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -1,8 +1,7 @@
-<h1 class="text-3xl mt-5 mb-15 text-center">ルーティン新規作成</h1>
-
+<h1 class="text-lg mt-5 mb-5 text-center sm:text-2xl md:text-3xl lg:text-4xl">ルーティン新規作成</h1>
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "キャンセル", root_path, class: "btn btn-outline btn-default mx-auto mb-5" %> <br>
-  <%= link_to "ルーティン一覧ページへ", routines_path, class: "link link-info mx-auto" %>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
+  <%= link_to "ルーティン一覧ページへ", routines_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -2,6 +2,6 @@
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
   <%= link_to "ルーティン一覧ページへ", routines_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -29,7 +29,7 @@
         <%= render "routines/task_form", task: @task, routine: @routine %>
         <div class="modal-action">
           <form method="dialog">
-            <button class="btn">閉じる</button>
+            <button class="btn bg-gradient-to-tl from-gray-300 to-gray-100 btn-md">閉じる</button>
           </form>
         </div>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
     <% end %>
 
     <div class="flex items-center ">
-      <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class:"hidden md:btn md:btn-outline md:bg-gray-100 hover:bg-gray-500 md:text-gray-500 mx-3 max-w-32 lg:max-w-40 lg:btn-lg lg:mx-5" %>
+      <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class:"hidden md:btn md:btn-outline md:bg-gradient-to-tl md:from-gray-300 md:to-gray-100 hover:bg-gray-500 md:text-gray-500 mx-3 max-w-32 lg:max-w-40 lg:btn-lg lg:mx-5" %>
       <%= link_to user_path(current_user), class: "hover:opacity-50 hover:border" do %>
         <%= image_tag "user_icon.jpg", class:"items-center mx-3 rounded-lg size-8 md:size-12 lg:size-14 lg:mx-5" %>
       <% end %>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,13 +1,9 @@
 <%= form_with url: login_path, class:"text-center" do |f| %>
   <div class="my-8">
-    <%= f.label :email, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.email_field :email, class:"grow", placeholder: "メールアドレス" %>
-    <% end %>
+    <%= f.email_field :email, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "メールアドレス" %>
   </div>
   <div class="my-8">
-    <%= f.label :password, class:"mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.password_field :password, class:"grow", placeholder: "パスワード" %>
-    <% end %>
+    <%= f.password_field :password, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "パスワード" %>
   </div>
-  <%= f.submit "ログイン", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+  <%= f.submit "ログイン", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
 <% end %>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -5,5 +5,5 @@
   <div class="my-8">
     <%= f.password_field :password, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "パスワード" %>
   </div>
-  <%= f.submit "ログイン", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
+  <%= f.submit "ログイン", class:"btn bg-gradient-to-tl from-emerald-400 to-emerald-100 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
 <% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="text-center">
-  <h1 class="text-3xl mt-5 mb-15">ユーザーログイン</h1>
+  <h1 class="text-xl font-semibold mt-5 mb-15 text-center sm:text-3xl lg:text-4xl">ユーザーログイン</h1>
   <%= render "form" %>
-  <%= link_to "キャンセル", root_path, class: "btn btn-outline btn-default mx-auto mb-5" %> <br>
-  <%= link_to "新規登録ページへ", new_user_path, class: "link link-info mx-auto" %>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %><br>
+  <%= link_to "新規登録ページへ", new_user_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="text-center">
   <h1 class="text-xl font-semibold mt-5 mb-15 text-center sm:text-3xl lg:text-4xl">ユーザーログイン</h1>
   <%= render "form" %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %><br>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %><br>
   <%= link_to "新規登録ページへ", new_user_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -9,5 +9,5 @@
     <%= f.email_field :email, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "メールアドレス", value: user.email %>
   </div>
 
-  <%= f.submit "更新", class:"btn bg-sky-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40" %>
+  <%= f.submit "更新", class:"btn bg-sky-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
 <% end %>

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_with model: user, class:"text-center" do |f| %>
   <div class="my-8">
-    <%= f.label :name, "ユーザー名" %>
-    <%= f.text_field :name, class:"input input-bordered", placeholder: "ユーザー名", value: user.name %>
+    <%= f.label :name, "ユーザー名", class: "block font-semibold mb-2 sm:text-lg" %>
+    <%= f.text_field :name, class: "block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "ユーザー名", value: user.name %>
   </div>
 
   <div class=" my-8 ">
-    <%= f.label :email, "メールアドレス" %>
-    <%= f.email_field :email, class:"input input-bordered", placeholder: "メールアドレス", value: user.email %>
+    <%= f.label :email, "メールアドレス", class: "block font-semibold mb-2 sm:text-lg" %>
+    <%= f.email_field :email, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "メールアドレス", value: user.email %>
   </div>
 
-  <%= f.submit "更新", class:"btn btn-outline btn-accent mb-5 w-1/6" %>
+  <%= f.submit "更新", class:"btn bg-sky-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40" %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,27 +1,19 @@
 <%= form_with model:user, class:"text-center" do |f| %>
   <div class="mx-auto my-8">
-    <%= f.label :name, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.text_field :name, class:"grow", placeholder: "ユーザー名" %>
-    <% end %>
+    <%= f.text_field :name, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "ユーザー名" %>
   </div>
 
   <div class="mx-auto my-8">
-    <%= f.label :email, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.email_field :email, class:"grow", placeholder: "メールアドレス" %>
-    <% end %>
+    <%= f.email_field :email, class:"block input input-bordered mx-auto w-8/12 md:text-lg lg:w-1/2", placeholder: "メールアドレス" %>
   </div>
 
   <div class="mx-auto my-8">
-    <%= f.label :password, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.password_field :password, class:"grow", placeholder: "パスワード" %>
-    <% end %>
+    <%= f.password_field :password, class:"block input input-bordered text-lg mx-auto w-8/12 md:text-xl lg:w-1/2", placeholder: "パスワード" %>
   </div>
 
   <div class="mx-auto my-8">
-    <%= f.label :password_confirmation, class: "mx-auto flex items-center gap-2 input input-bordered w-1/3" do %>
-      <%= f.password_field :password_confirmation, class:"grow", placeholder: "パスワード確認" %>
-    <% end %>
+    <%= f.password_field :password_confirmation, class:"block input input-bordered text-lg mx-auto w-8/12 md:text-xl lg:w-1/2", placeholder: "パスワード確認" %>
   </div>
 
-  <%= f.submit "登録", class:"btn btn-outline btn-accent mb-5 w-1/3" %>
+  <%= f.submit "登録", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40" %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -15,5 +15,5 @@
     <%= f.password_field :password_confirmation, class:"block input input-bordered text-lg mx-auto w-8/12 md:text-xl lg:w-1/2", placeholder: "パスワード確認" %>
   </div>
 
-  <%= f.submit "登録", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40" %>
+  <%= f.submit "登録", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -15,5 +15,5 @@
     <%= f.password_field :password_confirmation, class:"block input input-bordered text-lg mx-auto w-8/12 md:text-xl lg:w-1/2", placeholder: "パスワード確認" %>
   </div>
 
-  <%= f.submit "登録", class:"btn bg-emerald-400 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
+  <%= f.submit "登録", class:"btn bg-gradient-to-tl from-emerald-400 to-emerald-100 mb-5 btn-md min-w-28 sm:text-lg sm:btn-lg sm:min-w-40 lg:min-w-60" %>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,6 @@
-<h1 class="text-center my-10 items-center text-3xl">プロフィール</h1>
+<h1 class="text-center my-10 text-xl font-semibold sm:text-3xl lg:text-4xl">プロフィール編集</h1>
 
 <div class="text-center">
   <%= render "edit_form", user: @user %>
-  <%= link_to "キャンセル", user_path(current_user), class: "btn btn-outline btn-default mx-auto mb-5" %> <br>
+  <%= link_to "キャンセル", user_path(current_user), class: "btn btn-outline btn-default mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,5 +2,5 @@
 
 <div class="text-center">
   <%= render "edit_form", user: @user %>
-  <%= link_to "キャンセル", user_path(current_user), class: "btn btn-outline btn-default mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
+  <%= link_to "キャンセル", user_path(current_user), class: "btn bg-gray-300 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
-<h1 class="text-3xl mt-5 mb-15 text-center">ユーザー新規登録</h1>
+<h1 class="text-xl font-semibold mt-5 mb-15 text-center sm:text-3xl lg:text-4xl">ユーザー新規登録</h1>
 
 <div class="text-center">
   <%= render "form", user:@user %>
-  <%= link_to "キャンセル", root_path, class: "btn btn-outline btn-default mx-auto mb-5" %> <br>
-  <%= link_to "ログインページへ", login_path, class: "link link-info mx-auto" %>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
+  <%= link_to "ログインページへ", login_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,6 @@
 
 <div class="text-center">
   <%= render "form", user:@user %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gray-300 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
+  <%= link_to "キャンセル", root_path, class: "btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
   <%= link_to "ログインページへ", login_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>


### PR DESCRIPTION
## 概要
フォームのデザインを調整する
## やったこと
- 以下の画面にある入力フォームのデザインを調整する
  - ユーザー登録フォーム
  - ユーザー編集フォーム
  - ログインフォーム
  - ルーティン作成フォーム
  - ルーティン編集フォーム
  - タスク作成フォーム
  - タスク編集フォーム
- 上記のフォームおよびマイページに配置されたボタンのデザインを調整する
- 上記のデザインはレスポンシブに対応させる
## 変更結果
- ユーザー新規登録
<img src="https://i.gyazo.com/3ba68cb04c984f9ed17cc1312b906318.jpg" width="320">
- ログイン
<img src="https://i.gyazo.com/f0c0395f6cf329c0992dc2acd146d62b.jpg" width="320">
- ユーザープロフィール編集
<img src="https://i.gyazo.com/24f981a718f97d45d9931fb3c6bc6a1d.jpg" width="320">
- ルーティン作成(スマホ画面)
<img src="https://i.gyazo.com/92b0e7b381a3b628c1a9689f4e893390.png" width="320">
- ルーティン編集(Ipad画面)
<img src="https://i.gyazo.com/9480b1c901c63d8e560ed5a00d7afbb2.jpg" width="320">
- タスク作成
<img src="https://i.gyazo.com/ef7ba8548bc50701f38d8173fc80371b.png" width="320">
- タスク編集
<img src="https://i.gyazo.com/787cb74261ebeba3cfb030d2aea5de88.png" width="320">
## 注意点
- タスク作成・編集フォームはモーダルで表示されるフォーム部分のデザインのみを調整した。そのため、ルーティン詳細画面のデザインを別に調整する必要がある
## Issue
closes #21 
closes #23
closes #33
closes #39 
closes #52 
closes #55  