### PR TITLE
ユーザー詳細画面のデザイン：レスポンシブ

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,23 +1,32 @@
+<h1 class="text-xl font-semibold my-5 text-center sm:text-3xl lg:text-4xl">プロフィール</h1>
 
-<h1 class="text-center my-10 items-center text-3xl">プロフィール</h1>
+<div class="bg-gradient-to-tl from-cyan-200/60 to-cyan-50/60 w-11/12 mx-auto p-5 border border-sky-300 sm:w-9/12 sm:p-10 lg:w-8/12">
+  <%= image_tag "user_icon.jpg", class:"items-start rounded-lg mx-auto max-w-fit max-h-32 mb-5 md:max-h-48 lg:max-h-60" %>
+  <div class="sm:text-lg md:text-xl">
+    <div class="my-5 flex flex-row gap-2 items-center md:gap-4 sm:justify-center">
+      <p class="flex-none font-medium">名前:</p>
+      <p class="break-all md:font-semibold"><%= current_user.name %></p>
+    </div>
 
-<div class="w-1/2 mx-auto mt-10 border border-sky-300">
-  <%= image_tag "user_icon.jpg", size:"200x200", class:"items-center mx-auto my-5" %>
-  <p class="my-5 text-center">
-    ユーザー名：  <span class="text-xl"><%= current_user.name %></span>
-  </p>
+    <div class="my-5 flex flex-row gap-2 items-center md:gap-4 sm:justify-center">
+      <p class="flex-none font-medium">メール:</p>
+      <p class="break-all md:font-semibold"><%= current_user.email %></p>
+    </div>
 
-  <p class="my-5 text-center">
-    メールアドレス：  <span class="text-xl"><%= current_user.email %></span>
-  </p>
+    <div class="my-5 flex flex-row gap-2 items-center md:gap-4 sm:justify-center">
+      <p class="flex-none font-medium">ルーティン達成回数:</p>
+      <p class="font-semibold"><%= current_user.complete_routines_count %></p>
+    </div>
+  </div>
 
-  <p class="my-5 text-center">
-    ルーティン達成日数： <span class="text-xl"><%= current_user.complete_routines_count %></span>
-  </p>
-  <%= link_to "プロフィールを編集", edit_user_path(current_user), class:"btn btn-accent flex w-1/4 mx-auto my-5" %>
+  <div class="text-center">
+    <%= link_to "プロフィールを編集", edit_user_path(current_user), class: "btn bg-gradient-to-tl from-emerald-400 to-emerald-100 mb-5 btn-md min-w-28 md:text-lg md::btn-lg md:min-h-16 sm:min-w-40" %>
+  </div>
+
+  <div class="text-center">
+    <%= link_to "戻る", root_path, class:"btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto min-w-20 md:text-lg md:btn-lg sm:max-w-36" %>
+  </div>
 </div>
 
-<div class="w-1/2 mx-auto">
-  <%= link_to "戻る", root_path, class:"btn btn-outline flex w-1/4 mx-auto my-5" %>
-</div>
+
 


### PR DESCRIPTION
## 概要
ユーザー詳細画面のデザインをtailwindCssで調整する
## やったこと
- ユーザー詳細画面のデザインを調整する
- レスポンシブデザインにする
## 変更結果
- スマホ画面
  <img src="https://i.gyazo.com/65f1a63ee6f73afcf5716e098d8ecdb0.png" width="320">
- PC画面
  <img src="https://i.gyazo.com/59684f758a82d4c7ab9d4294a555a54e.jpg" width="320">
## Issue
closes #29