### PR TITLE
ルーティン詳細画面のデザイン：レスポンシブ

### DIFF
--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -1,28 +1,29 @@
-<%= link_to "戻る", routines_path, class:"btn btn-outline mx-10 mt-10" %>
-<div class="mx-auto my-5 w-1/2 border border-green-300 p-5 bg-sky-100">
-  <div class="flex justify-between items-center my-5 mx-3">
-    <h1 class="text-3xl border-b border-cyan-300 bg-white p-2"><%= @routine.title %></h1>
-    <div class="flex">
-      <%= link_to "編集", edit_routine_path(@routine), class: "btn btn-outline btn-success btn-md mr-3" %>
-      <%= link_to "削除", routine_path(@routine), data: { turbo_method: :delete }, class: "btn btn-outline btn-error btn-md" %>
+
+<div class="border border-amber-300 p-3 my-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 md:w-9/12">
+  <%= link_to "一覧に戻る", routines_path, class:"btn text-sm mb-5 bg-gradient-to-tl from-gray-300 to-gray-100 btn-md sm:text-base sm:min-w-28 md:btn-lg md:mb-10" %>
+  <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
+    <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
+      <%= link_to "編集", edit_routine_path(@routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-md md:text-base" %>
+      <%= link_to "削除", routine_path(@routine), data: { turbo_method: :delete, turbo_confirm: "#{@routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-md md:text-base" %>
     </div>
+    <h1 class="break-words bg-gray-50/40 rounded-lg p-3 font-semibold border-b border-orange-200 my-2 text-2xl md:text-3xl lg:text-4xl"><%= @routine.title %></h1>
   </div>
 
-  <div class="my-5 bg-white p-2">
-    <p class="py-1">説明文：</p>
+  <div class="mb-5 mx-auto bg-gray-50/70 p-3 sm:p-5">
     <p><%= @routine.description %></p>
   </div>
-  <div class="flex my-5">
-    <p class="mr-5 p-2 bg-gray-100">開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
-    <p class="mr-5 p-2 bg-gray-100">目安達成時間:</p>
-    <p class="mr-5 p-2 bg-gray-100">達成回数： <%= @routine.completed_count %></p>
+
+  <div class="mb-5 mx-3 text-sm flex flex-col gap-2 sm:flex-row sm:justify-between sm:justify-start sm:text-base sm:mx-5 sm:gap-5 md:text-lg lg:gap-10 lg:mx-16">
+    <p>開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
+    <p>目安達成時間:</p>
+    <p>達成回数： <%= @routine.completed_count %></p>
   </div>
 
 
   
   <div class="text-center p-5 bg-gray-100">
     <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine } %>
-    <button class="btn bg-green-100 w-full text-center" onclick="task_form.showModal()">タスクを追加</button>
+    <button class="btn bg-gradient-to-tl from-emerald-200 to-emerald-50 w-full text-center" onclick="task_form.showModal()"><span class="text-blue-500">＋</span>タスクを追加</button>
     <dialog id="task_form" class="modal">
       <div class="modal-box">
         <h1 class="text-center text-xl mb-10">タスク新規作成</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-xl font-semibold my-5 text-center sm:text-3xl lg:text-4xl">プロフィール</h1>
 
-<div class="bg-gradient-to-tl from-cyan-200/60 to-cyan-50/60 w-11/12 mx-auto p-5 border border-sky-300 sm:w-9/12 sm:p-10 lg:w-8/12">
+<div class="bg-gradient-to-tl from-cyan-200/60 to-cyan-0/60 rounded-lg w-11/12 mx-auto p-5 border border-sky-300 sm:w-9/12 sm:p-10 lg:w-8/12">
   <%= image_tag "user_icon.jpg", class:"items-start rounded-lg mx-auto max-w-fit max-h-32 mb-5 md:max-h-48 lg:max-h-60" %>
   <div class="sm:text-lg md:text-xl">
     <div class="my-5 flex flex-row gap-2 items-center md:gap-4 sm:justify-center">


### PR DESCRIPTION
## 概要
ルーティン詳細画面のデザインを調整する
## やったこと
- ルーティン詳細画面のデザインを調整する
- デザインをレスポンシブに対応させる
## 変更結果
- IphoneSE
  <img src="https://i.gyazo.com/3ec9f515448f4927383f0706e84bc8d0.png" width="320">
- PC
  <img src="https://i.gyazo.com/0d5417636eb0183bc633e5d7f71c8a50.jpg" width="320">
## Issue
closes #45