### PR TITLE
タスク遂行画面およびルーティン達成画面のデザイン

### DIFF
--- a/app/controllers/routines/finishes_controller.rb
+++ b/app/controllers/routines/finishes_controller.rb
@@ -1,3 +1,15 @@
 class Routines::FinishesController < ApplicationController
-  def index; end
+  skip_before_action :playing_task_sesison_reset
+  before_action :block_if_no_session
+
+  def index
+    current_user.complete_routines_count += 1
+    current_user.save!
+  end
+
+  private
+
+  def block_if_no_session
+    redirect_to root_path, alert: "ページに遷移できませんでした" if session[:playing_task_num].nil?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <div class="min-h-screen bg-repeat-y bg-[url('morning_phone.jpg')]  lg:bg-[url('morning_pc.jpg')]">
-      <div class="mt-12 sm:mt-16 md:mt-20 lg:mt-24 w-4/5 border h-full mx-auto bg-gray-100 bg-opacity-80">
+      <div class="mt-12 sm:mt-16 md:mt-20 lg:mt-24 w-4/5 border h-full mx-auto bg-gray-100/80 min-h-screen">
         <%= render "shared/flash" unless flash.empty? %>
         <%= yield %>
       </div>

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -1,4 +1,4 @@
-<div class="p-3 my-5 mx-auto bg-amber-300 bg-opacity-60 sm:w-11/12 md:w-9/12">
+<div class="p-3 my-5 mx-auto bg-gradient-to-tl from-amber-200/60 to-amber-100/60 sm:w-11/12 md:w-9/12">
 
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end sm:order-last sm:ml-auto">
@@ -26,5 +26,4 @@
       <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
     </div>
   </details>
-
 </div>

--- a/app/views/routines/finishes/index.html.erb
+++ b/app/views/routines/finishes/index.html.erb
@@ -1,4 +1,16 @@
-<div class="text-center m-10 w-3/4 mx-auto ">
-  <h1 class="my-10 text-4xl">Have a nice day!!</h1>
-  <%= link_to "マイページへ", root_path, class: "btn btn-outline btn-lg text-green-500 bg-green-100" %>
+<div class="p-3 my-10 mx-auto w-11/12 sm:w-9/12">
+
+  <div class="my-5 text-center rounded p-3">
+    <h1 class="text-lg font-semibold lg:text-3xl">ルーティンを達成しました！</h1>
+  </div>
+  <div class="bg-gradient-to-tl from-yellow-300/80 to-yellow-100/60 rounded-full p-3 flex flex-col gap-3 justify-center w-52 h-52 mb-5 mx-auto sm:gap-5 sm:w-56 sm:h-56 md:w-60 md:h-60 lg:w-96 lg:h-96 lg:gap-8">
+    <h1 class="text-xl text-center mx-auto sm:text-2xl lg:text-3xl">素敵な一日を!!</h1>
+    <p class="text-sm text-center mx-auto md:text-base">
+      ルーティン達成数：
+      <span class="text-blue-500 text-base font-bold sm:text-lg md:text-xl"><%= current_user.complete_routines_count %></span>
+    </p>
+    <div class="text-center">
+      <%= link_to "マイページへ", root_path, class: "btn bg-gradient-to-tl from-pink-300 to-pink-100 btn-sm text-xs min-h-10 sm:min-w-32 sm:min-h-12 md:text-sm md:min-w-36 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>
+    </div>
+  </div>
 </div>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -1,22 +1,22 @@
-<div class="my-5 text-center rounded p-3">
-  <h1 class="text-2xl"><%= @routine.title %></h1>
-</div>
-
 <div class="border border-amber-300 p-3 mb-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 sm:w-9/12">
   <div class="text-start">
     <%= link_to "x", root_path, class:"btn btn-sm btn-error m-5 sm:btn-md sm:min-w-12 sm:text-lg" %>
   </div>
-    <div class="bg-gradient-to-tl from-yellow-300 to-amber-50 rounded-full p-3 flex flex-col justify-center w-52 h-52 mb-5 mx-auto sm:w-56 sm:h-56 md:w-60 md:h-60 lg:w-72 lg:h-72">
-      <div class="text-2xl text-center mx-auto">
-        <p class="items-center"><%= @task.title %></p>
-      </div>
 
-      <div id="countdown-zone" class="text-2xl mx-auto p-3 flex justify-center gap-3">
-        <p><span id="hour"><%= @task.estimated_time[:hour] %></span>h</p>
-        <p><span id="minute"><%= @task.estimated_time[:minute] %></span>m</p>
-        <p><span id="second"><%= @task.estimated_time[:second] %></span>s</p>
-      </div>
+  <div class="my-5 text-center rounded p-3">
+    <h1 class="text-2xl lg:text-3xl"><%= @routine.title %></h1>
+  </div>
+
+  <div class="bg-gradient-to-tl from-yellow-300 to-amber-50 rounded-full p-3 flex flex-col justify-center w-52 h-52 mb-5 mx-auto sm:w-56 sm:h-56 md:w-60 md:h-60 lg:w-72 lg:h-72">
+    <div class="text-2xl text-center mx-auto lg:text-4xl">
+      <p class="items-center"><%= @task.title %></p>
     </div>
+    <div id="countdown-zone" class="text-2xl mx-auto p-3 flex justify-center gap-3 lg:text-4xl">
+      <p><span id="hour"><%= @task.estimated_time[:hour] %></span>h</p>
+      <p><span id="minute"><%= @task.estimated_time[:minute] %></span>m</p>
+      <p><span id="second"><%= @task.estimated_time[:second] %></span>s</p>
+    </div>
+  </div>
 
   <div class="flex justify-center gap-2 sm:gap-5 md:flex-col">
     <%= link_to "達成", play_path(@routine), data: { turbo_method: :patch }, class:"btn bg-gradient-to-tl from-pink-200 to-pink-50 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -1,21 +1,25 @@
-<div class="w-1/4 my-5 text-center mx-auto border border-amber-200 rounded bg-amber-100 p-3">
-  <h1 class="text-3xl "><%= @routine.title %></h1>
+<div class="my-5 text-center rounded p-3">
+  <h1 class="text-2xl"><%= @routine.title %></h1>
 </div>
 
-<div class="my-10 w-1/2 text-center mx-auto border border-green-200 rounded bg-sky-100">
+<div class="border border-amber-300 p-3 mb-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 sm:w-9/12">
   <div class="text-start">
-    <%= link_to "x", root_path, class:"btn btn-sm btn-error m-5 mr-10" %>
+    <%= link_to "x", root_path, class:"btn btn-sm btn-error m-5 sm:btn-md sm:min-w-12 sm:text-lg" %>
   </div>
-  <h1 class="text-3xl mb-10 bg-amber-100 rounded-full w-1/4 mx-auto p-3">
-    <%= @task.title %>
-  </h1>
+    <div class="bg-gradient-to-tl from-yellow-300 to-amber-50 rounded-full p-3 flex flex-col justify-center w-52 h-52 mb-5 mx-auto sm:w-56 sm:h-56 md:w-60 md:h-60 lg:w-72 lg:h-72">
+      <div class="text-2xl text-center mx-auto">
+        <p class="items-center"><%= @task.title %></p>
+      </div>
 
-  <div id="countdown-zone" class="text-2xl my-10 bg-white rounded-full w-1/2 mx-auto p-3 flex justify-center">
-    <p class="text-3xl mr-3"><span id="hour"><%= @task.estimated_time[:hour] %></span>h</p>
-    <p class="text-3xl mr-3"><span id="minute"><%= @task.estimated_time[:minute] %></span>m</p>
-    <p class="text-3xl mr-3"><span id="second"><%= @task.estimated_time[:second] %></span>s</p>
+      <div id="countdown-zone" class="text-2xl mx-auto p-3 flex justify-center gap-3">
+        <p><span id="hour"><%= @task.estimated_time[:hour] %></span>h</p>
+        <p><span id="minute"><%= @task.estimated_time[:minute] %></span>m</p>
+        <p><span id="second"><%= @task.estimated_time[:second] %></span>s</p>
+      </div>
+    </div>
+
+  <div class="flex justify-center gap-2 sm:gap-5 md:flex-col">
+    <%= link_to "達成", play_path(@routine), data: { turbo_method: :patch }, class:"btn bg-gradient-to-tl from-pink-200 to-pink-50 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>
+    <%= link_to "スキップ", play_path(@routine), data: { turbo_method: :patch }, class:"btn bg-gradient-to-tl from-blue-200 to-blue-50 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>
   </div>
-  
-  <%= link_to "達成", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-lg bg-green-200 my-10 mx-3" %>
-  <%= link_to "スキップ", play_path(@routine), data: { turbo_method: :patch }, class:"btn btn-lg bg-green-200 my-10 mx-3" %>
 </div>


### PR DESCRIPTION
## 概要
タスク遂行画面とルーティン達成画面のデザインを調整する
## やったこと
- タスク遂行画面とルーティン達成画面のデザインを調整する
- レスポンシブデザインにする
- ルーティン達成画面に遷移するとUsersテーブルのcomplete_routines_countカラムの値が加算される機能を実装する
## 変更結果
- タスク遂行画面：Iphone
<img src="https://i.gyazo.com/61ac10f46dca1a089165bc976a13daa2.png" width="320">
- タスク遂行画面：PC
<img src="https://i.gyazo.com/1345ad40a147361785506a83f728055f.jpg" width="480">
- ルーティン達成画面：Iphone
<img src="https://i.gyazo.com/bdecc4106acf827b8b0f09d0a78a219f.png" width="320">
- ルーティン達成画面：PC
<img src="https://i.gyazo.com/c5407ef2b2bb0e61bbef308899d5830d.jpg" width="480">
## Issue
closes #67 
closes #70 