### PR TITLE
Userモデルに関するテストを記述したspecファイルを作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,9 +13,6 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_new_params)
-    @user.role = 'general'
-    @user.complete_routines_count = 0
-
     if @user.save
       flash[:notice] = 'ユーザーを新しく追加しました'
       redirect_to login_path

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,6 +61,7 @@ development:
 test:
   <<: *default
   database: app_test
+  host: db
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20240902123606_change_column_default_to_users.rb
+++ b/db/migrate/20240902123606_change_column_default_to_users.rb
@@ -1,0 +1,6 @@
+class ChangeColumnDefaultToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :users, :role, from: nil, to: 1
+    change_column_default :users, :complete_routines_count, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_24_074112) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_02_123606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,8 +44,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_24_074112) do
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
-    t.integer "role", null: false
-    t.integer "complete_routines_count"
+    t.integer "role", default: 1, null: false
+    t.integer "complete_routines_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,21 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :user do
+    name                  { Faker::Name.name }
+    sequence(:email)      {  |n| "sample#{n}@example.com" }
+    password              { Faker::Alphanumeric.alphanumeric(number: 4) }
+    password_confirmation { password }
+
+    trait :no_match_password_confirmation do
+      password_confirmation { Faker::Alphanumeric.alphanumeric(number: 5) }
+    end
+
+    trait :no_attribute do
+      name                  { nil }
+      email                 { nil }
+      password              { nil }
+      password_confirmation { nil }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'バリデーションCheck' do
+    context 'ユーザーの新規登録' do
+      it 'name, email, password, password_confirmationが存在し、passwordが4文字以上であれば有効である + role, completed_routine_countのデフォルト値が設定されているか' do
+        user = create(:user)
+        expect(user).to be_valid
+        expect(user.errors).to be_empty
+        expect(user.role).to eq('general')
+        expect(user.complete_routines_count).to eq(0)
+      end
+
+      it 'name, email, password_confirmationのpresence: true + passwordのlength: {minimum: 4} が機能しているか' do
+        user = build(:user, :no_attribute)
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to eq ['を入力してください']
+        expect(user.errors[:email]).to eq ['を入力してください']
+        expect(user.errors[:password_confirmation]).to eq ['を入力してください']
+        expect(user.errors[:password]).to eq ['は4文字以上で入力してください']
+      end
+
+      it 'emailのuniqueness: trueが機能しているか' do
+        user1 = create(:user, email: 'test@ex.com')
+        user2 = build(:user, email: 'test@ex.com')
+        
+        expect(user1).to be_valid
+        expect(user1.errors).to be_empty
+        
+        expect(user2).not_to be_valid
+        expect(user2.errors[:email]).to eq ['はすでに存在します']
+      end
+
+      it 'passwordのconfirmation: trueが機能しているか' do
+        user = build(:user, :no_match_password_confirmation)
+        expect(user).to be_invalid
+        expect(user.errors[:password_confirmation]).to eq ['とパスワードの入力が一致しません']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - Userモデルのバリデーション、Usersテーブルのデフォルト値が機能しているかを確認する自動テストをrspecで実装する
 - Userモデルのrole, completed_routine_countカラムにデフォルト値を設定する
## やったこと
- userモデルのrole, completed_routine_countカラムにデフォルト値を設定するためのマイグレーションファイルを作成する
- テスト環境のDBで用いるhostをdbサービスに指定する
- テスト環境でrails db:createとrails db:migrateを実行する
- specファイルで使用するuserモデルインスタンスを用意するspec/factories/users.rbを作成する
- spec/models/user_spec.rbにUserモデルに関するテストを記述する
  - バリデーションが機能しているか
  - db/schema.rbに書かれたデフォルト値が機能しているか
## 変更結果
<img src="https://i.gyazo.com/f671343ad995f5e815fb81e6a867d891.png" width="400">
## Issue
closes #160