### PR TITLE
taskモデルの目安時間に関するyバリデーションを追加

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,13 @@ class Task < ApplicationRecord
   acts_as_list scope: :routine
 
   validates :title, presence: true, length: { maximum: 25 }
-  validates :estimated_time_in_second, presence: true
+  validates :estimated_time_in_second,
+    presence: true,
+    numericality: {
+      only_integer: true,
+      greater_than_or_equal_to: 1,
+      message: 'は1以上の整数を入力してください'
+    }
 
   def estimated_time
     result = second_to_time_string(estimated_time_in_second)


### PR DESCRIPTION
## 概要
taskのestimated_time_in_secondカラムの値が1以上の整数になるようにバリデーションを追加する

## やったこと
- app/models/task.rbにestimated_time_in_secondカラムの値が1以上の整数になるようにバリデーションを追加する
## Issue
closes #185 