### PR TITLE
ドラッグ&ドロップでTaskを並べ替えできる機能を追加

### DIFF
--- a/app/controllers/tasks/sorts_controller.rb
+++ b/app/controllers/tasks/sorts_controller.rb
@@ -1,0 +1,9 @@
+class Tasks::SortsController < ApplicationController
+  def update
+    @task = Task.find(params[:task_id])
+    @routine = @task.routine
+    @tasks = @routine.tasks
+
+    @task.insert_at(params[:new_index].to_i + 1)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,8 @@ module ApplicationHelper
   def shallow_bg_class
     request.path == root_path ? 'pb-16 mt-12 sm:mt-16 md:mt-20 lg:mt-24' : 'pb-16 mt-12 sm:mt-16 md:mt-20 lg:mt-24 w-4/5 border h-full mx-auto bg-blue-100/80 min-h-screen'
   end
+
+  def task_arrange_class(routine)
+    request.path == routine_path(routine) ? 'hover:border-green-500 hover:border-2' : ''
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,6 @@ module ApplicationHelper
   end
 
   def task_arrange_class(routine)
-    request.path == routine_path(routine) ? 'hover:border-green-500 hover:border-2' : ''
+    request.path == routines_path ? '' : 'hover:bg-amber-100'
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./routines_plays"
+import "./sortable"

--- a/app/javascript/sortable.js
+++ b/app/javascript/sortable.js
@@ -1,0 +1,12 @@
+import Sortable from 'sortablejs';
+
+document.addEventListener("turbo:load", function(event) {
+  const el = document.querySelector('#sortable-list');
+  if (el != null) {
+    Sortable.create(el, {
+      forceFallback: true,
+      fallbackClass: "sortable-fallback",
+      direction: 'vertical'
+    });
+  }
+});

--- a/app/javascript/sortable.js
+++ b/app/javascript/sortable.js
@@ -1,12 +1,26 @@
 import Sortable from 'sortablejs';
 
-document.addEventListener("turbo:load", function(event) {
+document.addEventListener('turbo:load', function(event) {
   const el = document.querySelector('#task-index');
   if (el != null) {
     Sortable.create(el, {
       forceFallback: true,
-      fallbackClass: "sortable-fallback",
-      direction: 'vertical'
+      fallbackClass: 'sortable-fallback',
+      direction: 'vertical',
+      onUpdate: function (event) {
+        const itemElement = event.item;
+        const taskId = itemElement.querySelector('.task-id').textContent;
+        const oldIndex = event.oldIndex;
+        const newIndex = event.newIndex;
+
+        const oldIndexForm = itemElement.querySelector(`#form-old-index-${taskId}`);
+        const newIndexForm = itemElement.querySelector(`#form-new-index-${taskId}`);
+        const submitBtn = itemElement.querySelector(`#sort-btn-${taskId}`);
+
+        oldIndexForm.value = oldIndex;
+        newIndexForm.value = newIndex;
+        submitBtn.click();
+      }
     });
   }
 });

--- a/app/javascript/sortable.js
+++ b/app/javascript/sortable.js
@@ -10,14 +10,11 @@ document.addEventListener('turbo:load', function(event) {
       onUpdate: function (event) {
         const itemElement = event.item;
         const taskId = itemElement.querySelector('.task-id').textContent;
-        const oldIndex = event.oldIndex;
         const newIndex = event.newIndex;
 
-        const oldIndexForm = itemElement.querySelector(`#form-old-index-${taskId}`);
         const newIndexForm = itemElement.querySelector(`#form-new-index-${taskId}`);
         const submitBtn = itemElement.querySelector(`#sort-btn-${taskId}`);
 
-        oldIndexForm.value = oldIndex;
         newIndexForm.value = newIndex;
         submitBtn.click();
       }

--- a/app/javascript/sortable.js
+++ b/app/javascript/sortable.js
@@ -1,7 +1,7 @@
 import Sortable from 'sortablejs';
 
 document.addEventListener("turbo:load", function(event) {
-  const el = document.querySelector('#sortable-list');
+  const el = document.querySelector('#task-index');
   if (el != null) {
     Sortable.create(el, {
       forceFallback: true,

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -1,6 +1,6 @@
 class Routine < ApplicationRecord
   belongs_to :user
-  has_many :tasks, dependent: :destroy
+  has_many :tasks, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 500 }

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -44,9 +44,9 @@
   </div>
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
-    <div class="collapse-content">
+    <ul class="collapse-content list-group" id="sortable-list">
       <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
-    </div>
+    </ul>
   </details>
 
 </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -44,7 +44,7 @@
   </div>
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
-    <ul class="collapse-content list-group" id="sortable-list">
+    <ul class="collapse-content">
       <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
     </ul>
   </details>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -3,7 +3,7 @@
     <div class="flex justify-between items-center mb-5">
       <h1 class="text-xs border-b border-cyan-300 font-semibold sm:text-sm md:text-base lg:text-lg"><%= task.title %></h1>
       <div class="flex-none">
-        <button class="min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()">編集</button>
+        <button class="btn bg-gradient-to-tl from-green-300 hover:opacity-50 to-green-100 text-xs btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()">編集</button>
         <dialog id="edit_task_form_<%= task.id %>" class="modal">
           <div class="modal-box">
             <h1 class="text-center text-xl mb-10">タスク編集</h1>
@@ -15,7 +15,7 @@
             </div>
           </div>
         </dialog>
-        <%= link_to "削除", task_path(task), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-sm sm:btn-md md:text-base" %>
+        <%= link_to "削除", task_path(task), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base" %>
       </div>
     </div>
     <div class="text-xs items-center sm:text-sm sm:flex sm:justify-between md:text-md lg:text-lg">
@@ -40,7 +40,6 @@
 
   <div class="hidden task-id"><%= task.id %></div>
   <%= form_with url: tasks_sort_path(task), method: "patch" do |f| %>
-    <%= f.hidden_field :old_index, value: "", id: "form-old-index-#{task.id}" %>
     <%= f.hidden_field :new_index, value: "", id: "form-new-index-#{task.id}" %>
     <%= f.submit nil, class: "hidden", id: "sort-btn-#{task.id}" %>
   <% end %>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -1,4 +1,4 @@
-<li id="task_<%= task.id %>" class="list-group-item">
+<li id="task_<%= task.id %>" class="list-group-item <%= task_arrange_class(routine) %>">
   <div class="border border-green-300 p-1 mb-3">
     <div class="flex justify-between items-center mb-5">
       <h1 class="text-xs border-b border-cyan-300 font-semibold sm:text-sm md:text-base lg:text-lg"><%= task.title %></h1>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -37,4 +37,11 @@
       </span>
     </div>
   </div>
+
+  <div class="hidden task-id"><%= task.id %></div>
+  <%= form_with url: tasks_sort_path(task), method: "patch" do |f| %>
+    <%= f.hidden_field :old_index, value: "", id: "form-old-index-#{task.id}" %>
+    <%= f.hidden_field :new_index, value: "", id: "form-new-index-#{task.id}" %>
+    <%= f.submit nil, class: "hidden", id: "sort-btn-#{task.id}" %>
+  <% end %>
 </li>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="task_<%= task.id %>">
+<li id="task_<%= task.id %>" class="list-group-item">
   <div class="border border-green-300 p-1 mb-3">
     <div class="flex justify-between items-center mb-5">
       <h1 class="text-xs border-b border-cyan-300 font-semibold sm:text-sm md:text-base lg:text-lg"><%= task.title %></h1>
@@ -37,4 +37,4 @@
       </span>
     </div>
   </div>
-</div>
+</li>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -30,9 +30,9 @@
   </div>
   
   <div class="text-center p-5 bg-gray-100">
-    <div id="task_index">
+    <ul class="list-group" id="task-index">
       <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine } %>
-    </div>
+    </ul>
     <div id="add_task_btn">
       <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @task } %>
     </div>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.update "flash" do %>
   <%= render partial: 'shared/flash' %>
 <% end %>
-<%= turbo_stream.append "task_index" do %>
+<%= turbo_stream.append "task-index" do %>
   <%= render partial: 'routines/task', locals: { routine: @routine, task: @task } %>
 <% end %>
 <%= turbo_stream.update "add_task_btn" do %>

--- a/app/views/tasks/sorts/update.turbo_stream.erb
+++ b/app/views/tasks/sorts/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "task-index" do %>
+  <%= render partial: 'routines/task', collection: @tasks, locals: { routine: @routine } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,5 +26,6 @@ Rails.application.routes.draw do
   namespace :tasks do
     resources :move_highers, only: %i[update], param: :task_id
     resources :move_lowers, only: %i[update], param: :task_id
+    resources :sorts, only: %i[update], param: :task_id
   end
 end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.10",
     "postcss": "^8.4.41",
+    "sortablejs": "^1.15.3",
     "tailwindcss": "^3.4.10"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,6 +828,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sortablejs@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.3.tgz#033668db5ebfb11167d1249ab88e748f27959e29"
+  integrity sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==
+
 source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"


### PR DESCRIPTION
## 概要
- yarnからSortableJSを導入する
- ドラッグ＆ドロップでタスクのpositionカラムを更新することができる機能を実装する
## やったこと
- sortablejsをインストールする
- app/javascript/sortable.jsを作成する
- タスクの並べ替え処理を行うapp/controllers/tasks/sorts_controller.rbを作成する
- ルーティングを追加する
- 並べ替え処理を行うため、ルーティン詳細画面にタスクのposition情報をTasksSortsコントローラに送信するフォームを作成する
## Issue
closes #187
closes #188