### PR TITLE
投稿をコピーした際にtaskのpositionカラムの値が意図しないものになる不具合を修正

### DIFF
--- a/app/controllers/routines/copies_controller.rb
+++ b/app/controllers/routines/copies_controller.rb
@@ -27,7 +27,9 @@ class Routines::CopiesController < ApplicationController
 
   def copy_tasks(routine_origin, routine_dup)
     routine_origin.tasks.each do |task|
-      task.dup.update!(routine_id: routine_dup.id)
+      task_dup = task.dup
+      task_dup.update!(routine_id: routine_dup.id)
+      task_dup.insert_at(task.position)
     end
   end
 end


### PR DESCRIPTION
## 概要
投稿をコピーした際にtaskのpositionカラムの値が正しくコピーされない不具合を修正する
## 原因
- task.dupによって作成されたTaskインスタンスは元のtaskインスタンスと同じroutine_idを持つ。そのため、DBに保存される際、acts_as_listの機能によってpositionカラムが自動的にコピー元のtaskインスタンスと同じにならないように補正されてしまう。
- なので、routine_idを変更した状態で保存したのち、positionカラムの値をコピー元のtaskインスタンスと同じ値になるように変更する処理を追加する必要がある

## やったこと
- task.dupで作成したインスタンスをDBに保存したのち、acts_as_listのinsert_atメソッドを用いて、コピーしたtaskインスタンスのpositionカラムの値をコピー元のpositionカラムと同じ値に変更する処理を加える。