### PR TITLE
tagモデルの作成

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :tasks, through: :task_tags
+  has_many :task_tags, dependent: :destroy
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,8 @@
 class Task < ApplicationRecord
   belongs_to :routine
+  has_many :tags, through: :task_tags
+  has_many :task_tags, dependent: :destroy
+
   acts_as_list scope: :routine
 
   validates :title, presence: true, length: { maximum: 25 }

--- a/app/models/task_tag.rb
+++ b/app/models/task_tag.rb
@@ -1,4 +1,6 @@
 class TaskTag < ApplicationRecord
   belongs_to :tag
   belongs_to :task
+
+  validates :task_id, uniqueness: { scope: tag_id }
 end

--- a/app/models/task_tag.rb
+++ b/app/models/task_tag.rb
@@ -1,0 +1,4 @@
+class TaskTag < ApplicationRecord
+  belongs_to :tag
+  belongs_to :task
+end

--- a/db/migrate/20240911081417_create_tags.rb
+++ b/db/migrate/20240911081417_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240911081633_create_task_tags.rb
+++ b/db/migrate/20240911081633_create_task_tags.rb
@@ -6,5 +6,6 @@ class CreateTaskTags < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
+    add_index :task_tags, [:task_id, :tag_id], unique: true
   end
 end

--- a/db/migrate/20240911081633_create_task_tags.rb
+++ b/db/migrate/20240911081633_create_task_tags.rb
@@ -1,0 +1,10 @@
+class CreateTaskTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :task_tags do |t|
+      t.references :task, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,6 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_11_081633) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tag_id"], name: "index_task_tags_on_tag_id"
+    t.index ["task_id", "tag_id"], name: "index_task_tags_on_task_id_and_tag_id", unique: true
     t.index ["task_id"], name: "index_task_tags_on_task_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_02_123606) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_11_081633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,21 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_02_123606) do
     t.datetime "updated_at", null: false
     t.datetime "posted_at"
     t.index ["user_id"], name: "index_routines_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "task_tags", force: :cascade do |t|
+    t.bigint "task_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_task_tags_on_tag_id"
+    t.index ["task_id"], name: "index_task_tags_on_task_id"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -52,5 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_02_123606) do
   end
 
   add_foreign_key "routines", "users"
+  add_foreign_key "task_tags", "tags"
+  add_foreign_key "task_tags", "tasks"
   add_foreign_key "tasks", "routines"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,10 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+tag_names_list = ['運動・健康', '美容', '趣味', '学習', '仕事・タスク', '自己投資', '日課']
+tag_names_list.each do |tag_name|
+  Tag.create!(
+    name: tag_name
+  )
+end


### PR DESCRIPTION
## 概要
タスクにタグをつける機能を実装するため、以下のテーブルをDBに追加する
- Tagsテーブル
- TaskTagsテーブル

## やったこと
- DBに上記のテーブルを追加する
- Task:TagがM:Nになるようにアソシエーションを追加
- 中間テーブルについて、task_idとtag_idの組み合わせが一意になるようにDB制約を指定
- db/seed.rbにTag情報の初期値をTagsテーブルに追加する処理を記述
- Tagsテーブルの初期値は以下の通り
  - 運動・健康
  - 美容
  - 趣味
  - 学習
  - 仕事・タスク
  - 自己投資
  - 日課

## 注意点
Heroku側でもマイグレーションファイルとdb:seedの実行が必要

## Issue
#59

- [ ] 