### PR TITLE
タスクにタグを設定できる機能を実装

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -7,7 +7,7 @@ class RoutinesController < ApplicationController
 
   def show
     @task = Task.new
-    @tasks = @routine.tasks.order(position: :asc)
+    @tasks = @routine.tasks.includes(:tags).order(position: :asc)
   end
 
   def new

--- a/app/controllers/tasks/sorts_controller.rb
+++ b/app/controllers/tasks/sorts_controller.rb
@@ -2,7 +2,7 @@ class Tasks::SortsController < ApplicationController
   def update
     @task = Task.find(params[:task_id])
     @routine = @task.routine
-    @tasks = @routine.tasks
+    @tasks = @routine.tasks.includes(:tags)
 
     @task.insert_at(params[:new_index].to_i + 1)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,7 +11,7 @@ class TasksController < ApplicationController
       set_tags_on_task(@task, task_params[:tag_ids])
       flash.now[:notice] = 'タスクを追加しました'
     else
-      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.all })
+      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.includes(:tasks).all })
     end
   end
 
@@ -22,7 +22,7 @@ class TasksController < ApplicationController
       set_tags_on_task(@task, task_params[:tag_ids])
       flash.now[:notice] = 'タスクを更新しました'
     else
-      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.all })
+      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.includes(:tasks).all })
     end
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,17 +8,21 @@ class TasksController < ApplicationController
     @routine = current_user.routines.find(params[:routine_id])
     @task = @routine.tasks.new(task_params)
     if @task.save
+      set_tags_on_task(@task, task_params[:tag_ids])
       flash.now[:notice] = 'タスクを追加しました'
     else
-      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine })
+      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.all })
     end
   end
 
   def update
     if @task.update(task_params)
+      p task_params
+      delete_tags_from_task(@task, task_params[:tag_ids])
+      set_tags_on_task(@task, task_params[:tag_ids])
       flash.now[:notice] = 'タスクを更新しました'
     else
-      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine })
+      render turbo_stream: turbo_stream.replace(task_form_id(@task).to_s, partial: 'routines/task_form', locals: { task: @task, routine: @routine, tags: Tag.all })
     end
   end
 
@@ -31,12 +35,26 @@ class TasksController < ApplicationController
   private
 
   def set_task_and_routine
-    @task = Task.find(params[:id])
+    @task = Task.includes(:tags).find(params[:id])
     @routine = @task.routine
   end
 
   def task_params
-    params.require(:task).permit(:title, :estimated_time_in_second)
+    params.require(:task).permit(:title, :estimated_time_in_second, tag_ids: [])
+  end
+
+  # 新しく指定されたタグをタスクに追加する
+  def set_tags_on_task(task, tag_ids)
+    return if tag_ids.nil?
+    tag_ids = tag_ids.map{ |tag_id| tag_id.to_i }
+    tag_ids.each{ |tag_id| task.tags << Tag.find(tag_id) unless task.tag_ids.include?(tag_id) }
+  end
+
+  # 元々セットされていたが今回選択されていなかったタグを削除
+  def delete_tags_from_task(task, tag_ids)
+    return if tag_ids.nil?
+    tag_ids = tag_ids.map{ |tag_id| tag_id.to_i }
+    task.tags.each{ |tag| task.tags.destroy(tag) unless tag_ids.include?(tag) }
   end
 
   def params_time_to_second

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -52,7 +52,7 @@ class TasksController < ApplicationController
 
   # 元々セットされていたが今回選択されていなかったタグを削除
   def delete_tags_from_task(task, tag_ids)
-    return if tag_ids.nil?
+    tag_ids = [] if tag_ids.nil?
     tag_ids = tag_ids.map{ |tag_id| tag_id.to_i }
     task.tags.each{ |tag| task.tags.destroy(tag) unless tag_ids.include?(tag) }
   end

--- a/app/javascript/sortable.js
+++ b/app/javascript/sortable.js
@@ -7,6 +7,7 @@ document.addEventListener('turbo:load', function(event) {
       forceFallback: true,
       fallbackClass: 'sortable-fallback',
       direction: 'vertical',
+      delay: 100,
       onUpdate: function (event) {
         const itemElement = event.item;
         const taskId = itemElement.querySelector('.task-id').textContent;

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,9 @@
 class Tag < ApplicationRecord
-  has_many :tasks, through: :task_tags
   has_many :task_tags, dependent: :destroy
+  has_many :tasks, through: :task_tags
+
+  # タグがタスクに設定されているかどうか
+  def is_on_task?(task)
+    return self.tasks.include?(task)
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   belongs_to :routine
-  has_many :tags, through: :task_tags
   has_many :task_tags, dependent: :destroy
+  has_many :tags, through: :task_tags
 
   acts_as_list scope: :routine
 

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -39,7 +39,7 @@
         <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
           <summary class="collapse-title">タスク一覧</summary>
           <div class="collapse-content">
-            <%= render partial: "task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
+            <%= render partial: "task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine } %>
           </div>
         </details>
       <% end %>

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -16,7 +16,7 @@
   </div>
   <div class="flex items-center gap-3 my-1 text-xs sm:text-sm md:text-md lg:text-lg">
     <% task.tags.each do |tag| %>
-      <p class="rounded-lg p-1 bg-amber-200"><%= tag.name %></p>
+      <p class="bg-gradient-to-tl from-amber-300 to-amber-50 rounded-lg p-1"><%= tag.name %></p>
     <% end %>
   </div>
 

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -14,5 +14,10 @@
       <%= task.estimated_time[:second] %> s
     </p>
   </div>
+  <div class="flex items-center gap-3 my-1 text-xs sm:text-sm md:text-md lg:text-lg">
+    <% task.tags.each do |tag| %>
+      <p class="rounded-lg p-1 bg-amber-200"><%= tag.name %></p>
+    <% end %>
+  </div>
 
 </div>

--- a/app/views/my_pages/_task.html.erb
+++ b/app/views/my_pages/_task.html.erb
@@ -1,20 +1,6 @@
 <div class="border border-green-200 p-1 mb-3">
   <div class="flex justify-between gap-2 items-center mb-5 mx-3">
     <h1 class="text-sm border-b border-cyan-300 font-semibold sm:text-base md:text-lg lg:text-xl"><%= task.title %></h1>
-    <div class="flex-none">
-      <button class="min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_in_mypage_<%= task.id %>').showModal()">編集</button>
-      <dialog id="edit_task_form_in_mypage_<%= task.id %>" class="modal mx-auto">
-        <div class="modal-box">
-          <h1 class="text-center text-lg font-semibold mb-5 sm:text-xl md:text-2xl lg:text-3xl md:mb-10">タスク編集</h1>
-          <%= render partial: "routines/task_form", locals: { task: task, routine: routine } %>
-          <div class="modal-action">
-            <form method="dialog">
-              <button class="btn btn-sm bg-gray-200 text-sm border min-h-12 sm:btn-md sm:text-base md:min-h-16 lg:text-lg lg:btn-lg">キャンセル</button>
-            </form>
-          </div>
-        </div>
-      </dialog>
-    </div>
   </div>
   <div class="flex text-xs sm:text-sm md:text-md lg:text-lg">
     <p class="font-medium mr-1">目安時間：</p>

--- a/app/views/routines/_add_task_btn.html.erb
+++ b/app/views/routines/_add_task_btn.html.erb
@@ -2,7 +2,7 @@
 <dialog id="task_form" class="modal">
   <div class="modal-box">
     <h1 class="text-center text-xl mb-10">タスク新規作成</h1>
-    <%= render "routines/task_form", task: task, routine: routine %>
+    <%= render "routines/task_form", task: task, routine: routine, tags: tags %>
     <div class="modal-action">
       <form method="dialog">
         <button class="btn bg-gradient-to-tl from-gray-300 to-gray-100 btn-md">閉じる</button>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -45,7 +45,7 @@
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
     <ul class="collapse-content">
-      <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine, tags: Tag.all } %>
+      <%= render partial: "routines/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine, tags: Tag.all } %>
     </ul>
   </details>
 

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -45,7 +45,7 @@
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
     <ul class="collapse-content">
-      <%= render partial: "routines/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine, tags: Tag.all } %>
+      <%= render partial: "routines/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine, tags: Tag.includes(:tasks).all } %>
     </ul>
   </details>
 

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -45,7 +45,7 @@
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
     <ul class="collapse-content">
-      <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
+      <%= render partial: "routines/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine, tags: Tag.all } %>
     </ul>
   </details>
 

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -36,6 +36,11 @@
         <%= link_to "↓", tasks_move_lower_path(task), data: { turbo_method: :patch }, class:"btn bg-gradient-to-tl from-blue-300 to-blue-100 btn-sm sm:min-w-12 lg:btn-md lg:text-lg" %>
       </span>
     </div>
+    <div class="flex flex-wrap items-center gap-1 my-1 text-xs sm:text-sm md:text-md md:gap-3 lg:text-lg">
+      <% task.tags.each do |tag| %>
+        <p class="rounded-lg p-1 bg-amber-200 flex-none"><%= tag.name %></p>
+      <% end %>
+    </div>
   </div>
 
   <div class="hidden task-id"><%= task.id %></div>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -38,7 +38,7 @@
     </div>
     <div class="flex flex-wrap items-center gap-1 my-1 text-xs sm:text-sm md:text-md md:gap-3 lg:text-lg">
       <% task.tags.each do |tag| %>
-        <p class="rounded-lg p-1 bg-amber-200 flex-none"><%= tag.name %></p>
+        <p class="bg-gradient-to-tl from-amber-300 to-amber-50 rounded-lg p-1 flex-none"><%= tag.name %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -7,7 +7,7 @@
         <dialog id="edit_task_form_<%= task.id %>" class="modal">
           <div class="modal-box">
             <h1 class="text-center text-xl mb-10">タスク編集</h1>
-            <%= render partial: "routines/task_form", locals: { task: task, routine: routine } %>
+            <%= render partial: "routines/task_form", locals: { task: task, routine: routine, tags: tags } %>
             <div class="modal-action">
               <form method="dialog">
                 <button class="btn">キャンセル</button>

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -18,6 +18,17 @@
       </div>
     </div>
 
+    <div class="flex flex-wrap gap-4">
+      <% tags.each do |tag| %>
+        <div class="flex-none">
+          <%= f.label "tag_ids_#{tag.id}" do %>
+            <%= f.check_box :tag_ids, { multiple: true, include_hidden: false }, tag.id, tag.is_on_task?(task) %>
+            <%= tag.name %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
     <%= f.submit nil, class:"btn bg-gradient-to-tl from-green-300 to-green-100 mb-5 btn-md min-w-28 mx-auto sm:btn-lg sm:text-lg lg:min-w-64 lg-text-xl" %>
   <% end %>
 </div>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -7,6 +7,12 @@
     <h1 class="text-2xl lg:text-3xl"><%= @routine.title %></h1>
   </div>
 
+  <div class="flex flex-wrap justify-center items-center gap-1 mb-3 text-sm sm:text-md md:text-lg md:gap-3 lg:text-xl">
+    <% @task.tags.each do |tag| %>
+      <p class="bg-gradient-to-tl from-amber-300 to-amber-50 rounded-lg p-1 flex-none md:p-3"><%= tag.name %></p>
+    <% end %>
+  </div>
+
   <div class="bg-gradient-to-tl from-yellow-300 to-amber-50 rounded-full p-3 flex flex-col justify-center w-52 h-52 mb-5 mx-auto sm:w-56 sm:h-56 md:w-60 md:h-60 lg:w-72 lg:h-72">
     <div class="text-lg text-center mx-auto lg:text-2xl">
       <p class="items-center"><%= @task.title %></p>

--- a/app/views/routines/posts/_posted_routine.html.erb
+++ b/app/views/routines/posts/_posted_routine.html.erb
@@ -44,7 +44,7 @@
   <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
     <summary class="collapse-title">タスク一覧</summary>
     <div class="collapse-content">
-      <%= render partial: "routines/posts/task", collection: routine.tasks.order(position: :asc), locals: { routine: routine } %>
+      <%= render partial: "routines/posts/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine } %>
     </div>
   </details>
 

--- a/app/views/routines/posts/_task.html.erb
+++ b/app/views/routines/posts/_task.html.erb
@@ -13,10 +13,10 @@
       <%= task.estimated_time[:second] %> s
     </p>
   </div>
-  
+
   <div class="flex flex-wrap items-center gap-1 my-1 text-xs sm:text-sm md:text-md md:gap-3 lg:text-lg">
     <% task.tags.each do |tag| %>
-      <p class="rounded-lg p-1 bg-amber-200 flex-none"><%= tag.name %></p>
+      <p class="bg-gradient-to-tl from-amber-300 to-amber-50 rounded-lg p-1 flex-none"><%= tag.name %></p>
     <% end %>
   </div>
 

--- a/app/views/routines/posts/_task.html.erb
+++ b/app/views/routines/posts/_task.html.erb
@@ -13,5 +13,11 @@
       <%= task.estimated_time[:second] %> s
     </p>
   </div>
+  
+  <div class="flex flex-wrap items-center gap-1 my-1 text-xs sm:text-sm md:text-md md:gap-3 lg:text-lg">
+    <% task.tags.each do |tag| %>
+      <p class="rounded-lg p-1 bg-amber-200 flex-none"><%= tag.name %></p>
+    <% end %>
+  </div>
 
 </div>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -32,11 +32,11 @@
   <div class="text-center p-5 bg-gray-100">
     <!-- タスク一覧を表示 -->
     <ul class="list-group" id="task-index">
-      <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine, tags: Tag.all } %>
+      <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine, tags: Tag.includes(:tasks).all } %>
     </ul>
     <!-- タスク追加ボタンを表示 -->
     <div id="add_task_btn">
-      <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @task, tags: Tag.all } %>
+      <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
     </div>
   </div>
 </div>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -30,11 +30,13 @@
   </div>
   
   <div class="text-center p-5 bg-gray-100">
+    <!-- タスク一覧を表示 -->
     <ul class="list-group" id="task-index">
-      <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine } %>
+      <%= render partial: "routines/task", collection: @tasks, locals: { routine: @routine, tags: Tag.all } %>
     </ul>
+    <!-- タスク追加ボタンを表示 -->
     <div id="add_task_btn">
-      <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @task } %>
+      <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @task, tags: Tag.all } %>
     </div>
   </div>
 </div>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -2,8 +2,8 @@
   <%= render partial: 'shared/flash' %>
 <% end %>
 <%= turbo_stream.append "task-index" do %>
-  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task } %>
+  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.all } %>
 <% end %>
 <%= turbo_stream.update "add_task_btn" do %>
-  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @routine.tasks.new } %>
+  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @routine.tasks.new, tags: Tag.all } %>
 <% end %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -2,8 +2,8 @@
   <%= render partial: 'shared/flash' %>
 <% end %>
 <%= turbo_stream.append "task-index" do %>
-  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.all } %>
+  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
 <% end %>
 <%= turbo_stream.update "add_task_btn" do %>
-  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @routine.tasks.new, tags: Tag.all } %>
+  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @routine.tasks.new, tags: Tag.includes(:tasks).all } %>
 <% end %>

--- a/app/views/tasks/sorts/update.turbo_stream.erb
+++ b/app/views/tasks/sorts/update.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "task-index" do %>
-  <%= render partial: 'routines/task', collection: @tasks, locals: { routine: @routine, tags: Tag.all } %>
+  <%= render partial: 'routines/task', collection: @tasks, locals: { routine: @routine, tags: Tag.includes(:tasks).all } %>
 <% end %>

--- a/app/views/tasks/sorts/update.turbo_stream.erb
+++ b/app/views/tasks/sorts/update.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "task-index" do %>
-  <%= render partial: 'routines/task', collection: @tasks, locals: { routine: @routine } %>
+  <%= render partial: 'routines/task', collection: @tasks, locals: { routine: @routine, tags: Tag.all } %>
 <% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= render partial: 'shared/flash' %>
 <% end %>
 <%= turbo_stream.update "task_#{@task.id}" do %>
-  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task } %>
+  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.all } %>
 <% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= render partial: 'shared/flash' %>
 <% end %>
 <%= turbo_stream.update "task_#{@task.id}" do %>
-  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.all } %>
+  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
 <% end %>


### PR DESCRIPTION
## 概要
- タスクにタグをつける機能を実装するため、tasksコントローラのcreate, updateアクションにタグを追加する処理を実装
- タスクフォームにタグをチェックボックスで選択できるようにする

## やったこと
- タスクの編集ボタンをマイページに表示しない
- app/controllers/tasks_controller.rbのcreateアクションとupdateアクションにTagを設定する機能を実装
- Viewまたはturbo_streamでrenderメソッドを用いてパーシャルに遷移する部分について、パーシャル内のtags変数が正常に使用できるように変更
- Viewのタスク一覧を表示する部分に各タスクに紐づいたタグ情報を表示する

## 変更結果
<img src="https://i.gyazo.com/1516a35ec74cdda96545581a224cd842.jpg" width="400">
<img src="https://i.gyazo.com/32283402e299c19997e84ddaa42c1549.jpg" width="400">
<img src="https://i.gyazo.com/e278002b86361a4ff5bac8a6a20bc06a.jpg" width="400">

## Issue
#60