### PR TITLE
ルーティン・タスク削除機能・「実践する」「投稿する」ボタン機能のajax

### DIFF
--- a/app/controllers/routines/actives_controller.rb
+++ b/app/controllers/routines/actives_controller.rb
@@ -1,11 +1,10 @@
 class Routines::ActivesController < ApplicationController
   def update
-    routine = current_user.routines.find(params[:routine_id])
-    routine_active_now = current_user.routines.find_by(is_active: true)
-    unless routine == routine_active_now
-      routine_active_now&.update!(is_active: false)
-      routine.update!(is_active: true)
+    @routine = current_user.routines.find(params[:routine_id])
+    @routine_active_now = current_user.routines.find_by(is_active: true)
+    unless @routine == @routine_active_now
+      @routine_active_now&.update!(is_active: false)
+      @routine.update!(is_active: true)
     end
-    redirect_to routines_path
   end
 end

--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -4,13 +4,13 @@ class Routines::PostsController < ApplicationController
   end
 
   def update
-    routine = current_user.routines.find(params[:routine_id])
-    if routine.is_posted?
-      routine.update!(is_posted: false)
-      redirect_to routines_path, notice: 'ルーティンを非公開にしました'
+    @routine = current_user.routines.includes(:tasks).find(params[:routine_id])
+    if @routine.is_posted?
+      @routine.update!(is_posted: false)
+      flash.now[:notice] = 'ルーティンを非公開にしました'
     else
-      routine.update!(is_posted: true, posted_at: Time.current)
-      redirect_to routines_path, notice: 'ルーティンを投稿しました'
+      @routine.update!(is_posted: true, posted_at: Time.current)
+      flash.now[:notice] = 'ルーティンを投稿しました'
     end
   end
 end

--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -4,7 +4,7 @@ class Routines::PostsController < ApplicationController
   end
 
   def update
-    @routine = current_user.routines.includes(:tasks).find(params[:routine_id])
+    @routine = current_user.routines.find(params[:routine_id])
     if @routine.is_posted?
       @routine.update!(is_posted: false)
       flash.now[:notice] = 'ルーティンを非公開にしました'

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -37,8 +37,11 @@ class RoutinesController < ApplicationController
 
   def destroy
     @routine.destroy!
+    from_path = params[:from_path] # 遷移元のパス、どのページから削除したのかを判別する
     flash[:alert] = "#{@routine.title}を削除しました"
-    redirect_to routines_path, status: :see_other
+
+    # 「詳細ページから削除した場合」または「ルーティンを削除したことでユーザーに属するルーティンが0個になった場合」は一覧画面にリダイレクト
+    redirect_to routines_path, status: :see_other if from_path == routine_path(@routine) || current_user.routines.empty?
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,7 +17,6 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      p task_params
       delete_tags_from_task(@task, task_params[:tag_ids])
       set_tags_on_task(@task, task_params[:tag_ids])
       flash.now[:notice] = 'タスクを更新しました'
@@ -29,7 +28,6 @@ class TasksController < ApplicationController
   def destroy
     @task.destroy!
     flash[:notice] = "タスクを削除しました。(タスク名：#{@task.title})"
-    redirect_to routine_path(@routine), status: :see_other
   end
 
   private

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -32,11 +32,9 @@
     </div>
 
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-      <% if routine.is_posted? %>
-        <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 text-sm md:text-base" %>
-      <% else %>
-        <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
-      <% end %>
+      <div id="routine-post-btn-<%= routine.id %>">
+        <%= render "routines/routine_post_btn", routine: routine %>
+      </div>
       <div id="routine-active-btn-<%= routine.id %>">
         <%= render "routines/routine_active_btn", routine: routine %>
       </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -1,52 +1,54 @@
-<div class="border border-amber-300 p-3 my-5 mx-auto bg-gradient-to-tl from-amber-200/70 to-yellow-50/70 sm:w-11/12 md:w-9/12">
+<div id="routine-<%= routine.id %>">
+  <div class="border border-amber-300 p-3 my-5 mx-auto bg-gradient-to-tl from-amber-200/70 to-yellow-50/70 sm:w-11/12 md:w-9/12">
 
-  <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
-    <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-      <%= link_to "編集", edit_routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base" %>
-      <%= link_to "詳細", routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-blue-300 to-blue-100 text-sm btn-sm sm:btn-md md:text-base" %>
-      <%= link_to "削除", routine_path(routine), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-sm sm:btn-md md:text-base" %>
+    <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
+      <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
+        <%= link_to "編集", edit_routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base" %>
+        <%= link_to "詳細", routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-blue-300 to-blue-100 text-sm btn-sm sm:btn-md md:text-base" %>
+        <%= link_to "削除", routine_path(routine), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-sm sm:btn-md md:text-base" %>
+      </div>
+      <h1 class="break-words text-xl font-semibold border-b border-orange-200 my-2 sm:text-2xl md:text-3xl lg:text-4xl"><%= routine.title %></h1>
     </div>
-    <h1 class="break-words text-xl font-semibold border-b border-orange-200 my-2 sm:text-2xl md:text-3xl lg:text-4xl"><%= routine.title %></h1>
-  </div>
 
-  <div class="mb-5 mx-auto bg-gray-100/80 p-3 sm:p-5">
-    <p><%= routine.description %></p>
-  </div>
-  
-  <div class="mb-5 text-xs flex justify-between sm:justify-start sm:gap-5 sm:text-sm sm:mx-3 lg:text-base lg:gap-10">
-    <p class="border-b border-orange-200">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
-    <p class="border-b border-orange-200">
-      目安時間：
-      <span>
-        <%= routine.total_estimated_time[:hour] %> h
-      </span>
-      <span>
-        <%= routine.total_estimated_time[:minute] %> m
-      </span>
-      <span>
-        <%= routine.total_estimated_time[:second] %> s
-      </span>
-    </p>
-    <p class="border-b border-orange-200">達成数： <%= routine.completed_count %></p>
-  </div>
+    <div class="mb-5 mx-auto bg-gray-100/80 p-3 sm:p-5">
+      <p><%= routine.description %></p>
+    </div>
 
-  <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-    <% if routine.is_posted? %>
-      <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 text-sm md:text-base" %>
-    <% else %>
-      <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
-    <% end %>
-    <% if routine.is_active? %>
-      <%= link_to "実践中", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border border-pink-300 text-sm md:text-base" %>
-    <% else %>
-      <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
-    <% end %>
-  </div>
-  <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
-    <summary class="collapse-title">タスク一覧</summary>
-    <ul class="collapse-content">
-      <%= render partial: "routines/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine, tags: Tag.includes(:tasks).all } %>
-    </ul>
-  </details>
+    <div class="mb-5 text-xs flex justify-between sm:justify-start sm:gap-5 sm:text-sm sm:mx-3 lg:text-base lg:gap-10">
+      <p class="border-b border-orange-200">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+      <p class="border-b border-orange-200">
+        目安時間：
+        <span>
+          <%= routine.total_estimated_time[:hour] %> h
+        </span>
+        <span>
+          <%= routine.total_estimated_time[:minute] %> m
+        </span>
+        <span>
+          <%= routine.total_estimated_time[:second] %> s
+        </span>
+      </p>
+      <p class="border-b border-orange-200">達成数： <%= routine.completed_count %></p>
+    </div>
 
+    <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
+      <% if routine.is_posted? %>
+        <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 text-sm md:text-base" %>
+      <% else %>
+        <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
+      <% end %>
+      <% if routine.is_active? %>
+        <%= link_to "実践中", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border border-pink-300 text-sm md:text-base" %>
+      <% else %>
+        <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
+      <% end %>
+    </div>
+    <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
+      <summary class="collapse-title">タスク一覧</summary>
+      <ul class="collapse-content">
+        <%= render partial: "routines/task", collection: routine.tasks.includes(:tags).order(position: :asc), locals: { routine: routine, tags: Tag.includes(:tasks).all } %>
+      </ul>
+    </details>
+
+  </div>
 </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -37,11 +37,9 @@
       <% else %>
         <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
       <% end %>
-      <% if routine.is_active? %>
-        <%= link_to "実践中", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border border-pink-300 text-sm md:text-base" %>
-      <% else %>
-        <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
-      <% end %>
+      <div id="routine-active-btn-<%= routine.id %>">
+        <%= render "routines/routine_active_btn", routine: routine %>
+      </div>
     </div>
     <details class="collapse bg-gradient-to-tl from-teal-200 to-teal-50 border border-green-200 items-center text-sm sm:text-base lg:text-lg">
       <summary class="collapse-title">タスク一覧</summary>

--- a/app/views/routines/_routine_active_btn.html.erb
+++ b/app/views/routines/_routine_active_btn.html.erb
@@ -1,0 +1,5 @@
+<% if routine.is_active? %>
+  <p class="btn bg-gradient-to-tl from-gray-300 to-gray-100 border border-pink-300 text-sm md:text-base">実践中</p>
+<% else %>
+  <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
+<% end %>

--- a/app/views/routines/_routine_post_btn.html.erb
+++ b/app/views/routines/_routine_post_btn.html.erb
@@ -1,0 +1,5 @@
+<% if routine.is_posted? %>
+  <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 text-sm md:text-base" %>
+<% else %>
+  <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base" %>
+<% end %>

--- a/app/views/routines/actives/update.turbo_stream.erb
+++ b/app/views/routines/actives/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update "routine-active-btn-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine_active_btn', locals: { routine: @routine } %>
+<% end %>
+
+<% if @routine_active_now %>
+  <%= turbo_stream.update "routine-active-btn-#{@routine_active_now.id}" do %>
+    <%= render partial: 'routines/routine_active_btn', locals: { routine: @routine_active_now } %>
+  <% end %>
+<% end %>

--- a/app/views/routines/destroy.turbo_stream.erb
+++ b/app/views/routines/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update "flash" do %>
+  <%= render partial: 'shared/flash' %>
+<% end %>
+<%= turbo_stream.remove "routine-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+<% end %>

--- a/app/views/routines/destroy.turbo_stream.erb
+++ b/app/views/routines/destroy.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= render partial: 'shared/flash' %>
 <% end %>
 <%= turbo_stream.remove "routine-#{@routine.id}" do %>
-  <%= render partial: 'routines/routine', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+  <%= render partial: 'routines/routine', locals: { routine: @routine } %>
 <% end %>

--- a/app/views/routines/posts/update.turbo_stream.erb
+++ b/app/views/routines/posts/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.update "flash" do %>
   <%= render partial: 'shared/flash' %>
 <% end %>
-<%= turbo_stream.update "routine-#{@routine.id}" do %>
-  <%= render partial: 'routines/routine', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+<%= turbo_stream.update "routine-post-btn-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine_post_btn', locals: { routine: @routine } %>
 <% end %>

--- a/app/views/routines/posts/update.turbo_stream.erb
+++ b/app/views/routines/posts/update.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update "flash" do %>
+  <%= render partial: 'shared/flash' %>
+<% end %>
+<%= turbo_stream.update "routine-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+<% end %>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -3,7 +3,7 @@
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
       <%= link_to "編集", edit_routine_path(@routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-md md:text-base" %>
-      <%= link_to "削除", routine_path(@routine), data: { turbo_method: :delete, turbo_confirm: "#{@routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-md md:text-base" %>
+      <%= link_to "削除", routine_path(@routine, from_path: request.path), data: { turbo_method: :delete, turbo_confirm: "#{@routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-md md:text-base" %>
     </div>
     <h1 class="break-words bg-gray-50/40 rounded-lg p-3 font-semibold border-b border-orange-200 my-2 text-2xl md:text-3xl lg:text-4xl"><%= @routine.title %></h1>
   </div>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "flash" do %>
+  <%= render partial: 'shared/flash' %>
+<% end %>
+
+<%= turbo_stream.remove "task_#{@task.id}" do %>
+  <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+<% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.update "flash" do %>
   <%= render partial: 'shared/flash' %>
 <% end %>
-<%= turbo_stream.update "task_#{@task.id}" do %>
+<%= turbo_stream.replace "task_#{@task.id}" do %>
   <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
 <% end %>


### PR DESCRIPTION
## 概要
以下の機能をturbo_streamでajax化する
- ルーティン削除機能
- タスク削除機能
- ルーティン投稿ボタン
- ルーティン実践ボタン

## やったこと
- ルーティン一覧画面からルーティンの削除を行う場合に、削除したルーティンの表示部分のみを更新する
- タスクを削除した場合に、削除したタスクの表示部分のみを更新する
- 「投稿」「実践」ボタンを押すと、投稿ボタンの表示部分のみが更新されるようにする

## Issue
closes #182 
closes #183 