### PR TITLE
タスク作成・更新・削除時にルーティンの合計時間の表示も更新されるように変更

### DIFF
--- a/app/controllers/routines/finishes_controller.rb
+++ b/app/controllers/routines/finishes_controller.rb
@@ -12,7 +12,7 @@ class Routines::FinishesController < ApplicationController
   private
 
   def block_if_no_session
-    redirect_to root_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
+    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
   end
 
   # 獲得した経験値情報から、UserTagExperiencesテーブルに情報を追加していく

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -38,7 +38,7 @@ class Routines::PlaysController < ApplicationController
 
   # createアクションを介さないアクセスを拒否
   def block_if_no_session
-    redirect_to root_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
+    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
   end
 
   # タグidと達成した回数を経験値管理ハッシュに格納する

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
     if @user
       flash[:notice] = 'ログインしました！'
-      redirect_to root_path
+      redirect_to my_pages_path
     else
       render :new
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,8 @@ module ApplicationHelper
     current_user ? "min-h-screen bg-repeat-y bg-[url('morning_phone.jpg')]  lg:bg-[url('morning_pc.jpg')]" : ''
   end
 
+  # 表示されているページがトップページかどうかでクラスを変更する
+  # 背景画像のデザインに関するクラス
   def shallow_bg_class
     request.path == root_path ? 'pb-16 mt-12 sm:mt-16 md:mt-20 lg:mt-24' : 'pb-16 mt-12 sm:mt-16 md:mt-20 lg:mt-24 w-4/5 border h-full mx-auto bg-blue-100/80 min-h-screen'
   end
@@ -21,5 +23,10 @@ module ApplicationHelper
 
   def task_form_id(task)
     task.id.nil? ? 'task-form-for-new' : "task-form-for-#{task.id}"
+  end
+
+  # ログインしているか否かでルートページへのパスを返す
+  def root_page
+    current_user ? my_pages_path : root_path
   end
 end

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1 class="text-center text-xl py-5 sm:text-2xl md:text-3xl lg:text-4xl xl:test-5xl">おはようございます！</h1>
+  <h1 class="text-center text-xl py-5 sm:text-2xl md:text-3xl lg:text-4xl xl:test-5xl">おはようございます！<br><%= current_user.name %>さん</h1>
 </div>
 <div class="flex justify-center gap-2 sm:gap-4 md:gap-8">
   <%= link_to "ルーティン作成", new_routine_path, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 btn-sm text-xs w-1/3 min-h-10 sm:w-36 sm:btn-md sm:text-sm md:text-base md:w-40 lg:text-lg lg:btn-lg lg:w-44" %>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -15,20 +15,11 @@
     </div>
 
     <div class="mb-5 text-xs flex justify-between sm:justify-start sm:gap-5 sm:text-sm sm:mx-3 lg:text-base lg:gap-10">
-      <p class="border-b border-orange-200">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
-      <p class="border-b border-orange-200">
-        目安時間：
-        <span>
-          <%= routine.total_estimated_time[:hour] %> h
-        </span>
-        <span>
-          <%= routine.total_estimated_time[:minute] %> m
-        </span>
-        <span>
-          <%= routine.total_estimated_time[:second] %> s
-        </span>
-      </p>
-      <p class="border-b border-orange-200">達成数： <%= routine.completed_count %></p>
+      <p>開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+      <div id="total-estimated-time-for-routine-<%= routine.id %>">
+        <%= render "routines/routine_total_estimated_time", routine: routine %>
+      </div>
+      <p>達成数： <%= routine.completed_count %></p>
     </div>
 
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">

--- a/app/views/routines/_routine_total_estimated_time.html.erb
+++ b/app/views/routines/_routine_total_estimated_time.html.erb
@@ -1,0 +1,12 @@
+<p>
+  目安時間：
+  <span>
+    <%= routine.total_estimated_time[:hour] %> h
+  </span>
+  <span>
+    <%= routine.total_estimated_time[:minute] %> m
+  </span>
+  <span>
+    <%= routine.total_estimated_time[:second] %> s
+  </span>
+</p>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -15,7 +15,7 @@
             </div>
           </div>
         </dialog>
-        <%= link_to "削除", task_path(task), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base" %>
+        <%= link_to "削除", task_path(task), data: { turbo_method: :delete }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base" %>
       </div>
     </div>
     <div class="text-xs items-center sm:text-sm sm:flex sm:justify-between md:text-md lg:text-lg">

--- a/app/views/routines/finishes/index.html.erb
+++ b/app/views/routines/finishes/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="text-center my-3">
-    <%= link_to "マイページへ", root_path, class: "btn bg-gradient-to-tl from-pink-300 to-pink-100 btn-sm text-xs min-h-10 sm:min-w-32 sm:min-h-12 md:text-sm md:min-w-36 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>
+    <%= link_to "マイページへ", my_pages_path, class: "btn bg-gradient-to-tl from-pink-300 to-pink-100 btn-sm text-xs min-h-10 sm:min-w-32 sm:min-h-12 md:text-sm md:min-w-36 md:mx-auto lg:text-lg lg:btn-lg lg:w-44" %>
   </div>
 
   <div class="bg-gradient-to-tl from-pink-200/80 to-pink-50 rounded-lg p-3 flex flex-col gap-1 justify-center mb-5 mx-auto">

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -2,6 +2,6 @@
 
 <div class="text-center">
   <%= render "form", routine: @routine %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gradient-to-tl from-gray-300 to-gray-200 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
+  <%= link_to "キャンセル", my_pages_path, class: "btn bg-gradient-to-tl from-gray-300 to-gray-200 mx-auto mb-5 btn-md text-sm min-w-28 sm:btn-lg sm:text-base lg:text-lg lg:btn-wide" %> <br>
   <%= link_to "ルーティン一覧ページへ", routines_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -1,6 +1,6 @@
 <div class="px-3 pb-5 my-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 sm:w-9/12">
   <div class="text-start">
-    <%= link_to "x", root_path, class:"btn btn-sm btn-error m-5 sm:btn-md sm:min-w-12 sm:text-lg" %>
+    <%= link_to "x", my_pages_path, class:"btn btn-sm btn-error m-5 sm:btn-md sm:min-w-12 sm:text-lg" %>
   </div>
 
   <div class="mb-5 text-center rounded p-3">

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -14,18 +14,9 @@
 
   <div class="mb-5 mx-3 text-sm flex flex-col gap-2 sm:flex-row sm:justify-between sm:justify-start sm:mx-5 sm:gap-5 lg:text-base lg:gap-10 lg:mx-16">
     <p>開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
-    <p>
-      目安時間：
-      <span>
-        <%= @routine.total_estimated_time[:hour] %> h
-      </span>
-      <span>
-        <%= @routine.total_estimated_time[:minute] %> m
-      </span>
-      <span>
-        <%= @routine.total_estimated_time[:second] %> s
-      </span>
-    </p>
+    <div id="total-estimated-time-for-routine-<%= @routine.id %>">
+      <%= render "routines/routine_total_estimated_time", routine: @routine %>
+    </div>
     <p>達成回数： <%= @routine.completed_count %></p>
   </div>
   
@@ -40,6 +31,3 @@
     </div>
   </div>
 </div>
-
-
-

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <div class="fixed top-0 z-10 w-full h-12 sm:h-16 md:h-20 lg:h-24 p-3 flex justify-between items-center bg-gradient-to-t from-sky-50 to-sky-200">
-    <%= link_to root_path, class:"btn btn-sm sm:btn-md lg:btn-lg w-28 sm:w-36 md:w-44 lg:w-48 btn-outline bg-white bg-opacity-30 text-green-600 hover:bg-green-500" do %>
+    <%= link_to root_page, class:"btn btn-sm sm:btn-md lg:btn-lg w-28 sm:w-36 md:w-44 lg:w-48 btn-outline bg-white bg-opacity-30 text-green-600 hover:bg-green-500" do %>
       <p class="flex items-center">
         <%= image_tag "logo.jpg", class: "rounded h-6 sm:h-8 md:h-10 mr-1 sm:mr-2 md:mr-3" %>
         <span class="text-xs sm:text-sm md:text-base">Morning Forest</span>
@@ -16,7 +16,6 @@
       <div class="drawer drawer-end mx-3 lg:mx-5">
         <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
-          <!-- Page content here -->
           <label for="my-drawer-4" class="drawer-button btn btn-sm bg-green-50 text-xl font-light sm:btn-md sm:text-3xl lg:size-14 lg:text-4xl">≡</label>
         </div>
         <div class="drawer-side mt-12 sm:mt-16 md:mt-20 lg:mt-24">
@@ -32,7 +31,7 @@
               <%= link_to "投稿一覧を見る", routines_posts_path, class:"p-3 mb-2 bg-gradient-to-tl from-cyan-300 to-cyan-100 text-xs sm:text-sm lg:text-base hover:opacity-50" %>
             </li>
             <li>
-              <%= link_to "マイページへ", root_path, class:"p-3 mb-2 bg-gradient-to-tl from-cyan-300 to-cyan-100 text-xs sm:text-sm lg:text-base hover:opacity-50" %>
+              <%= link_to "マイページへ", my_pages_path, class:"p-3 mb-2 bg-gradient-to-tl from-cyan-300 to-cyan-100 text-xs sm:text-sm lg:text-base hover:opacity-50" %>
             </li>
             <li>
               <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class:"p-3 mb-2 bg-gradient-to-tl from-gray-300 to-gray-100 text-xs sm:text-sm md:hidden hover:opacity-50" %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,9 +1,15 @@
 <%= turbo_stream.update "flash" do %>
   <%= render partial: 'shared/flash' %>
 <% end %>
+
 <%= turbo_stream.append "task-index" do %>
   <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
 <% end %>
+
 <%= turbo_stream.update "add_task_btn" do %>
-  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: @routine.tasks.new, tags: Tag.includes(:tasks).all } %>
+  <%= render partial: 'routines/add_task_btn', locals: { routine: @routine, task: Task.new, tags: Tag.includes(:tasks).all } %>
+<% end %>
+
+<%= turbo_stream.update "total-estimated-time-for-routine-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine_total_estimated_time', locals: { routine: @routine } %>
 <% end %>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -5,3 +5,7 @@
 <%= turbo_stream.remove "task_#{@task.id}" do %>
   <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
 <% end %>
+
+<%= turbo_stream.update "total-estimated-time-for-routine-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine_total_estimated_time', locals: { routine: @routine } %>
+<% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -1,6 +1,11 @@
 <%= turbo_stream.update "flash" do %>
   <%= render partial: 'shared/flash' %>
 <% end %>
+
 <%= turbo_stream.replace "task_#{@task.id}" do %>
   <%= render partial: 'routines/task', locals: { routine: @routine, task: @task, tags: Tag.includes(:tasks).all } %>
+<% end %>
+
+<%= turbo_stream.update "total-estimated-time-for-routine-#{@routine.id}" do %>
+  <%= render partial: 'routines/routine_total_estimated_time', locals: { routine: @routine } %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,6 @@
 
 <div class="text-center">
   <%= render "form", user:@user %>
-  <%= link_to "キャンセル", root_path, class: "btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
+  <%= link_to "キャンセル", my_pages_path, class: "btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto mb-5 min-w-20 sm:text-lg sm:btn-lg sm:max-w-36" %> <br>
   <%= link_to "ログインページへ", login_path, class: "link text-blue-600 mx-auto text-base sm:text-lg lg:text-xl" %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,9 +24,6 @@
   </div>
 
   <div class="text-center">
-    <%= link_to "戻る", root_path, class:"btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto min-w-20 md:text-lg md:btn-lg sm:max-w-36" %>
+    <%= link_to "戻る", my_pages_path, class:"btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto min-w-20 md:text-lg md:btn-lg sm:max-w-36" %>
   </div>
 </div>
-
-
-


### PR DESCRIPTION
## 概要
- タスク作成・更新・削除時にルーティンの合計時間の表示も更新されるように変更する
- マイページに遷移する際の遷移先のpathがroot_pathになっている部分をmy_pages_pathに遷移するように修正

## やったこと
- マイページに遷移する際の遷移先のpathがroot_pathになっている部分をmy_pages_pathに遷移するように修正
- タスク作成・更新・削除時にルーティンの合計時間の表示も更新されるように変更する

