### PR TITLE
Likesコントローラの修正

### DIFF
--- a/app/controllers/routines/likes_controller.rb
+++ b/app/controllers/routines/likes_controller.rb
@@ -16,6 +16,6 @@ class Routines::LikesController < ApplicationController
   private
 
   def set_routine
-    @routine = current_user.routines.find(params[:routine_id])
+    @routine = Routine.find(params[:routine_id])
   end
 end


### PR DESCRIPTION
## 概要
お気に入り機能が正常に動作しない不具合を修正

## やったこと
- Routines::Likesコントローラの一部処理を修正

## 原因
- お気に入り登録する対象となるRoutineモデルインスタンスを取得する際に、ログインユーザーに属するRoutineモデルインスタンスから取得してしまっていたため、ログインユーザーは自分の投稿に対してしかお気に入りできない
