### PR TITLE
オートログイン機能を実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,8 +14,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_new_params)
     if @user.save
+      auto_login(@user)
       flash[:notice] = 'ユーザーを新しく追加しました'
-      redirect_to login_path
+      redirect_to my_pages_path
     else
       flash.now[:alert] = 'ユーザーの作成に失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/views/routines/posts/_posted_routine.html.erb
+++ b/app/views/routines/posts/_posted_routine.html.erb
@@ -15,12 +15,7 @@
       <p class="flex-none font-medium">投稿者:</p>
       <p class="break-all font-semibold"><%= routine.user.name %></p>
     </div>
-    <div class="my-5 flex flex-row gap-2 items-center">
-      <p class="flex-none font-medium">コピー数:</p>
-      <p class="break-all font-semibold"><%= routine.copied_count %></p>
-    </div>
   </div>
-
   
   <div class="mb-5 mx-auto bg-gray-100/80 p-3 sm:p-5">
     <p><%= routine.description %></p>


### PR DESCRIPTION
## 概要
ユーザー新規登録時後に自動でログインできる機能を実装

## 問題点
* [x] ユーザーを新規登録した際、ログイン画面でもう一度情報を入力する手間があった

## やったこと
- ユーザー新規登録後にログインしてマイページに遷移するように修正
- ルーティン投稿一覧にコピー数を表示しないように変更
