### PR TITLE
sidekiq.rbのredis接続設定に自己証明書の検証を無効化する記述を追加

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,13 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV['REDIS_URL'] }
+  config.redis = {
+    url: ENV['REDIS_URL'],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV['REDIS_URL'] }
+  config.redis = {
+    url: ENV['REDIS_URL'],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
 end


### PR DESCRIPTION
## 概要
herokuで、redisサーバに接続できないエラーを解消する

## エラーメッセージ
SSL_connect returned=1 errno=0 peeraddr=~ state=error: certificate verify failed

## 問題点
redisに接続する際に使用するSSL暗号通信を行う際に必要な自己証明書の検証が失敗している

## 解決策
自己証明書の検証をスキップする

## やったこと
config/initializers/sidekiq.rbのredisサーバ接続設定に以下の記述を追加
- ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
