### PR TITLE
System spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Database Migration
         run: bundle exec rails db:migrate RAILS_ENV=test
 
+      - name: Build CSS
+        run: yarn build:css
+
       - name: Run Rspec
         run: bundle exec rspec
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-
+      selenium:
+        image: selenium/standalone-chrome
+        ports:
+          - 4444:4444
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build CSS
         run: yarn build:css
 
+      - name: Build Javascript
+        run: yarn build:css
+
       - name: Run Rspec
         run: bundle exec rspec
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         run: yarn build:css
 
       - name: Build Javascript
-        run: yarn build:css
+        run: yarn build
 
       - name: Run Rspec
         run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.3.4"
 
 # 警告メッセージを消す
 gem 'mutex_m'
+gem 'drb'
 #9 tailswindを導入
 gem "cssbundling-rails"
 #16 ユーザー登録機能

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :development, :test do
   # rspec: テスト用
   gem 'rspec-rails', '~> 6.1.0'
   gem 'factory_bot_rails'
+  gem "capybara"
+  gem "selenium-webdriver"
   # テスト用のダミーデータを作成
   gem 'faker'
 end
@@ -107,7 +109,4 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
-  gem "selenium-webdriver"
-
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
-    selenium-webdriver (4.23.0)
+    selenium-webdriver (4.25.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    drb (2.2.1)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
@@ -442,6 +443,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  drb
   factory_bot_rails
   faker
   fog-aws

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <div class="fixed top-0 z-50 w-full h-12 sm:h-16 md:h-20 py-3 px-1 sm:px-3 md:px-5 flex justify-between items-center bg-gradient-to-t from-sky-50 to-sky-200">
-    <%= link_to root_path, class:"btn btn-sm sm:btn-md lg:btn-lg w-28 sm:w-36 md:w-44 lg:w-48 btn-outline bg-white bg-opacity-30 text-green-600 hover:bg-green-500" do %>
+    <%= link_to root_path, class:"btn btn-sm sm:btn-md lg:btn-lg w-28 sm:w-36 md:w-44 lg:w-48 btn-outline bg-white bg-opacity-30 text-green-600 hover:bg-green-500", id: "header-logo" do %>
       <p class="flex items-center">
         <%= image_tag "logo.jpg", class: "rounded h-6 sm:h-8 md:h-10 mr-1 sm:mr-2 md:mr-3" %>
         <span class="text-xs sm:text-sm md:text-base">Morning Forest</span>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 sorcery:
   line_callback_url: 'https://7b24-133-200-130-0.ngrok-free.app/oauth/callback?provider=line'
 selenium:
-  url: "http://localhost:4444/wd/hub"
+  url: "http://selenium:4444/wd/hub"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 sorcery:
   line_callback_url: 'https://7b24-133-200-130-0.ngrok-free.app/oauth/callback?provider=line'
 selenium:
-	url: "http://localhost:4444/wd/hub"
+  url: "http://localhost:4444/wd/hub"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,4 @@
 sorcery:
   line_callback_url: 'https://7b24-133-200-130-0.ngrok-free.app/oauth/callback?provider=line'
+selenium:
+	url: "http://localhost:4444/wd/hub"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 sorcery:
   line_callback_url: 'https://7b24-133-200-130-0.ngrok-free.app/oauth/callback?provider=line'
 selenium:
-  url: "http://selenium:4444/wd/hub"
+  url: "http://localhost:4444/wd/hub"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: "3"
 services:
+  selenium:
+    image: selenium/standalone-chromium:latest
+    ports:
+      - "4444:4444"
   db:
     image: postgres
     platform: linux/amd64
@@ -34,8 +38,8 @@ services:
       - "3000:3000"
     depends_on:
       - db
-      - redis      
-
+      - redis
+      - selenium
 volumes:
   postgres_data:
   bundle_data:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,8 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
 # --------- System Specで使用するドライバの作成 ------------------
 Capybara.register_driver :remote_chrome do |app|
   url = Settings.selenium.url
@@ -54,8 +56,11 @@ end
 RSpec.configure do |config|
   
   # --------- System Specで使用するドライバの設定 ------------------
-  config.before(:each, type: :system, js: true) do
+  config.before(:each, type: :system) do
     driven_by :remote_chrome
+    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+    Capybara.server_port = 4444
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
   end
   # -------------------------------------------------------------
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
   
   # --------- System Specで使用するドライバの設定 ------------------
   config.before(:each, type: :system, js: true) do
-    driven_by :remote_chrome,
+    driven_by :remote_chrome
   end
   # -------------------------------------------------------------
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :remote_chrome
     Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 4444
+    Capybara.server_port = 4445
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
   end
   # -------------------------------------------------------------

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,28 @@ require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rspec'
+require 'selenium-webdriver'
+
+# --------- System Specで使用するドライバの作成 ------------------
+Capybara.register_driver :remote_chrome do |app|
+  url = Settings.selenium.url
+
+  options = Selenium::WebDriver::Chrome::Options.new
+	options.add_argument('--headless')
+	options.add_argument('--disable-gpu')
+	options.add_argument('--no-sandbox')
+	options.add_argument('--disable-dev-shm-usage')
+	options.add_argument('--window-size=1920,1080')
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :remote,
+    url: url,
+    capabilities: options
+  )
+end
+# -------------------------------------------------------------
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -30,6 +52,13 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  
+  # --------- System Specで使用するドライバの設定 ------------------
+  config.before(:each, type: :system, js: true) do
+    driven_by :remote_chrome,
+  end
+  # -------------------------------------------------------------
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')
 

--- a/spec/system/top_pages_spec.rb
+++ b/spec/system/top_pages_spec.rb
@@ -8,18 +8,56 @@ RSpec.describe "TopPages", type: :system do
       before do
         visit root_path
       end
+      
+      describe 'トップページのヘッダーに関するテスト' do
+        it 'トップページのヘッダーにログインボタンが表示される' do
+          expect(page).to have_link('ログイン')
+          click_link 'ログイン'
+          expect(page).to have_current_path(login_path)
+        end
 
-      it 'トップページにログイン前のヘッダーが表示されている' do
-        expect(page).to have_link('ログイン')
-        expect(page).to have_link('header-logo')
+        it 'トップページのヘッダーに新規登録ボタンが表示される' do
+          expect(page).to have_link('新規登録')
+          click_link '新規登録'
+          expect(page).to have_current_path(new_user_path)
+        end
+
+        it 'トップページのヘッダーにヘッダーロゴが表示される' do
+          expect(page).to have_link('header-logo')
+          find('#header-logo').click
+          expect(page).to have_current_path(root_path)
+        end
+
+        it 'トップページのヘッダーにお試しログインボタンが表示される' do
+          expect(page).to have_link('お試し')
+          click_link 'お試し'
+          expect(page).to have_current_path(my_pages_path)
+          expect(page).to have_content('ゲストログインしました。')
+        end
       end
 
-      it 'トップページにアプリタイトルが表示されている' do
-        expect(page).to have_selector('h1', text: 'Morning')
+      describe 'トップページのメインコンテンツに関するテスト' do
+        it 'トップページにアプリタイトルが表示されている' do
+          expect(page).to have_selector('h1', text: 'Morning')
+        end
+
+        it 'トップページにアプリの使い方が表示されている' do
+          expect(page).to have_selector('h1', text: 'アプリの使い方')
+        end
       end
 
-      it 'トップページにアプリの使い方が表示されている' do
-        expect(page).to have_selector('h1', text: 'アプリの使い方')
+      describe 'トップページのフッターに関するテスト' do
+        it 'トップページのフッターにプライバシーポリシーリンクが表示されている' do
+          expect(page).to have_link('プライバシーポリシー')
+          click_link('プライバシーポリシー')
+          expect(page).to have_current_path(policy_path)
+        end
+
+        it 'トップページのフッターにプライバシーポリシーリンクが表示されている' do
+          expect(page).to have_link('利用規約')
+          click_link('利用規約')
+          expect(page).to have_current_path(terms_path)
+        end
       end
     end
   end

--- a/spec/system/top_pages_spec.rb
+++ b/spec/system/top_pages_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "TopPages", type: :system do
+  let!(:user) { create(:user) }
+
+  describe 'トップページ（root_path）のUI' do
+    context 'ユーザーログイン前' do
+      before do
+        visit root_path
+      end
+
+      it 'トップページにログイン前のヘッダーが表示されている' do
+        expect(page).to have_link('ログイン')
+        expect(page).to have_link('header-logo')
+      end
+
+      it 'トップページにアプリタイトルが表示されている' do
+        expect(page).to have_selector('h1', text: 'Morning')
+      end
+
+      it 'トップページにアプリの使い方が表示されている' do
+        expect(page).to have_selector('h1', text: 'アプリの使い方')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
specのsystem specをgem capybaraを用いて実行するための初期設定を追加する。

## やったこと
- 以下のgemをdevelopment, test環境に導入
  - "selenium-webdriver"
  - "capybara"
- 開発環境に、system spec実行用のChromeドライバ・ブラウザを動作させるseleniumコンテナをdocker-compose.ymlに追加した。
- テスト環境(github actions)にsystem spec実行用のChromeドライバ・ブラウザを動作させるseleniumサービスを作成した。
- 以下のcapybaraの初期設定を追加した。
  - remote_chromeドライバはリモートのクローム（seleniumコンテナ）を操作するドライバに設定
  - 全てのsystem specで、remote_chromeをドライバとして使用するように設定
  - Capybara.server_portを4445に指定
  - 以下の特徴を持つブラウザを操作するカスタムドライバ（remote_chrome）を作成
    - ヘッドレスモード
    - サンドボックス機能は無効化
    - GPU無効化
    - /dev/shmの無効化
    - window-size=1920,1080

- github_actionsでsystem specを動作するように、test用ワークフローファイルに以下の処理を追加
  - cssのプリコンパイル(yarn build:cssを実行)
  - jsファイルのプリコンパイル(yarn buildの実行)

- トップページのsystem specを作成

##  変更結果
development環境でのsystem spec実行結果
<img src="https://i.gyazo.com/b275e983a2ce571c8264742af311b4e4.png" width="400">