### PR TITLE
通知方法を設定する機能

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on: push
 jobs:
   rspec-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     services:
       postgres:
         image: "postgres"

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+
+@import "tailwindcss/components";
+@import "./custom.css";
+
+@import "tailwindcss/utilities";

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -32,3 +32,7 @@
 .text-plane-custom {
   @apply text-xs md:text-sm;
 }
+
+.scroll-container-custom {
+  @apply max-h-screen overflow-scroll;
+}

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,0 +1,3 @@
+.btn-sm-custom {
+  @apply btn text-xs btn-sm md:h-8 md:text-sm hover:scale-105;
+}

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,3 +1,34 @@
 .btn-sm-custom {
-  @apply btn text-xs btn-sm md:h-8 md:text-sm hover:scale-105;
+  @apply btn text-xs btn-sm h-8 shadow-sm
+         md:text-sm 
+         hover:scale-105;
+}
+
+.btn-md-custom {
+  @apply btn text-xs btn-sm h-8 shadow-md
+         sm:h-10 md:text-sm 
+         hover:scale-105;
+}
+
+.btn-edit-custom {
+  @apply bg-gradient-to-tl from-green-300 to-green-100
+         hover:from-green-300 hover:to-green-300;
+}
+
+.btn-delete-custom {
+  @apply bg-gradient-to-tl from-red-400 to-red-200
+         hover:from-red-400 hover:to-red-400;
+}
+
+.btn-show-custom {
+  @apply bg-gradient-to-tl from-blue-300 to-blue-100
+         hover:from-blue-300 hover:to-blue-300;
+}
+
+.text-title-custom {
+  @apply border-b border-gray-400 font-semibold text-sm sm:text-base md:text-lg lg:text-xl;
+}
+
+.text-plane-custom {
+  @apply text-xs md:text-sm;
 }

--- a/app/assets/stylesheets/tailwindcss/base.css
+++ b/app/assets/stylesheets/tailwindcss/base.css
@@ -1,0 +1,1 @@
+@tailwind base;

--- a/app/assets/stylesheets/tailwindcss/components.css
+++ b/app/assets/stylesheets/tailwindcss/components.css
@@ -1,0 +1,1 @@
+@tailwind components;

--- a/app/assets/stylesheets/tailwindcss/utilities.css
+++ b/app/assets/stylesheets/tailwindcss/utilities.css
@@ -1,0 +1,1 @@
+@tailwind utilities;

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -65,7 +65,7 @@ class RoutinesController < ApplicationController
   end
 
   def routine_params
-    params.require(:routine).permit(:title, :description, :start_time)
+    params.require(:routine).permit(:title, :description, :start_time, :notification)
   end
 
   def set_routine

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,7 @@ module ApplicationHelper
     end
   end
 
+  # ----------- CSSクラスに関するヘルパー ---------------------------------------------
   def bg_image_class
     current_user ? "min-h-screen bg-repeat-y bg-[url('morning_phone.jpg')]  lg:bg-[url('morning_pc.jpg')]" : ''
   end
@@ -28,6 +29,7 @@ module ApplicationHelper
   def task_arrange_class
     request.path == routines_path ? '' : 'hover:bg-amber-100'
   end
+  # --------------------------------------------------------
 
   def task_form_id(task)
     task.id.nil? ? 'new' : "#{task.id}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,8 @@ module ApplicationHelper
     when policy_path, terms_path
       'mt-12 sm:mt-14 md:mt-16'
     else
-      'pb-16 mt-12 sm:mt-14 md:mt-16 w-4/5 border h-full mx-auto bg-green-100/90 min-h-screen'
+      'pb-16 mt-12 sm:mt-14 md:mt-16 h-full mx-auto bg-green-50/90 min-h-screen
+      w-11/12 sm:w-4/5'
     end
   end
 

--- a/app/jobs/set_notification_job.rb
+++ b/app/jobs/set_notification_job.rb
@@ -1,15 +1,20 @@
 class SetNotificationJob < ApplicationJob
   queue_as :default
 
+  # 全てのLINE登録済みユーザーに対し、ルーティンの開始時間にLINE Push通知を送信するJobを呼び出す
   def perform()
     time_now = Time.current
+    
     User.includes(:routines, :authentications).each do |user|
       user_line_authentication = user.authentications.find_by(provider: 'line', user_id: user.id)
       next unless user_line_authentication # UserがLineを介して登録していない場合はスキップ
 
       uid = user_line_authentication.uid
       active_routine = user.routines.find_by(is_active: true)
-      perform_line_notification_job(active_routine, uid, time_now) if active_routine
+      next unless active_routine
+
+      # 「ユーザーが実践中のルーティンの通知設定がline」の場合 => メソッド呼び出し
+      perform_line_notification_job(active_routine, uid, time_now) if active_routine.notification == "line"
     end
   end
 

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -7,6 +7,8 @@ class Routine < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 500 }
 
+  enum notification: { no: 0, line: 1 }
+
   scope :posted, -> { where(is_posted: true) }
   scope :unposted, -> { where(is_posted: false) }
   scope :my_post, ->(user_id)  { where(user_id: user_id) }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
   </head>
 
   <body class="h-full">
+
+    <!-- Header -->
     <% if current_user %>
       <%= render 'shared/header' %>
     <% else %>
@@ -26,13 +28,18 @@
 
     <div class="<%= bg_image_class %>">
       <div class="<%= shallow_bg_class %>">
+        <!-- Flashメッセージ -->
         <div id="flash">
           <%= render 'shared/flash' %>
         </div>
+
+        <!-- Main Content -->
         <%= yield %>
+
       </div>
     </div>
 
+    <!-- Footer -->
     <%= render 'shared/footer' %>
   </body>
 

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -10,10 +10,14 @@
   </div>
   
   <div class="mb-5 text-xs text-gray-600 sm:flex sm:flex-row sm:justify-start sm:text-base sm:gap-5 md:text-lg lg:gap-10">
-    <p class="">開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+    <p class="">
+      <span class="font-semibold">開始: </span>
+      <%= routine.start_time.strftime("%H:%M") if routine.start_time %>
+      （<%= I18n.t("activerecord.attributes.routine/notification.#{@routine.notification}") %>）
+    </p>
 
     <p class="">
-      合計時間:
+      <span class="font-semibold">合計: </span>
       <span>
         <%= routine.total_estimated_time[:hour] %>h
       </span>
@@ -25,7 +29,10 @@
       </span>
     </p>
 
-    <p class="">達成数: <%= routine.completed_count %></p>
+    <p class="">
+      <span class="font-semibold">達成数: </span>
+      <%= routine.completed_count %>
+    </p>
   </div>
 
   <div class="text-center mb-16">

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -1,4 +1,17 @@
-<h1 class="text-xl font-semibold my-5 text-center sm:text-3xl lg:text-4xl">称号一覧</h1>
+<div class="sm:flex sm:justify-between mt-3 sm:my-5 mx-5 sm:mx-7">
+  <div class="flex sm:basis-3/12">
+    <%= link_to "<マイページ", my_pages_path,
+      class: "btn text-xs bg-gradient-to-tl from-green-500 to-green-500 btn-sm min-h-9 mb-3
+              sm:min-w-28 sm:text-sm lg:btn-md
+              hover:from-gray-300 hover:to-gray-300 hover:scale-105"
+    %>
+  </div>
+
+  <h1 class="sm:basis-6/12 text-xl font-semibold text-center sm:text-3xl lg:text-4xl">称号一覧</h1>
+
+  <div class="sm:basis-3/12"></div>
+</div>
+
 
 <div class="p-4 grid sm:grid-cols-2 lg:grid-cols-3">
   <%= render @rewards %>

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="my-3">
     <p class="font-semibold text-xs sm:text-sm md:text-base">通知</p>
-    <%= f.select :notification, [['通知しない', 'no'], ['LINE (LINEログインした方のみ有効)', 'line']], { selected: routine.notification }, class: "mx-auto select select-bordered w-8/12 text-sm text-center min-h-6 h-8 lg:text-lg lg:p-2 lg:min-h-12" %>
+    <%= f.select :notification, [['通知オフ', 'no'], ['LINE (LINEログインした方のみ有効)', 'line']], { selected: routine.notification }, class: "mx-auto select select-bordered w-8/12 text-sm text-center min-h-6 h-8 lg:text-lg lg:p-2 lg:min-h-12" %>
   </div>
 
   <%= f.submit nil, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 my-3 w-4/12 text-xs btn-sm min-h-10 sm:btn-md sm:text-sm lg:text-base hover:from-cyan-100 hover:to-cyan-100 hover:text-gray-600" %>

--- a/app/views/routines/_form.html.erb
+++ b/app/views/routines/_form.html.erb
@@ -16,5 +16,10 @@
     <%= f.time_field :start_time, class: "mx-auto input input-bordered w-8/12 h-8 text-sm text-center lg:text-lg lg:min-h-12 lg:p-2", min: "00:00", max: "23:59" %>
   </div>
 
+  <div class="my-3">
+    <p class="font-semibold text-xs sm:text-sm md:text-base">通知</p>
+    <%= f.select :notification, [['通知しない', 'no'], ['LINE (LINEログインした方のみ有効)', 'line']], { selected: routine.notification }, class: "mx-auto select select-bordered w-8/12 text-sm text-center min-h-6 h-8 lg:text-lg lg:p-2 lg:min-h-12" %>
+  </div>
+
   <%= f.submit nil, class:"btn bg-gradient-to-tl from-cyan-300 to-cyan-100 my-3 w-4/12 text-xs btn-sm min-h-10 sm:btn-md sm:text-sm lg:text-base hover:from-cyan-100 hover:to-cyan-100 hover:text-gray-600" %>
 <% end %>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -15,11 +15,18 @@
     </div>
 
     <div class="mb-5 text-xs flex justify-between sm:justify-start sm:gap-5 sm:text-sm sm:mx-3 lg:text-base lg:gap-10">
-      <p>開始時間: <%= routine.start_time.strftime("%H:%M") if routine.start_time %></p>
+      <div>
+        <p>開始時間</p>
+        <%= routine.start_time.strftime("%H:%M") if routine.start_time %>
+      </div>
+
       <div id="total-estimated-time-for-routine-<%= routine.id %>">
         <%= render "routines/routine_total_estimated_time", routine: routine %>
       </div>
-      <p>達成数： <%= routine.completed_count %></p>
+      <div>
+        <p>達成数</p>
+        <%= routine.completed_count %>
+      </div>
     </div>
 
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
@@ -30,6 +37,7 @@
         <%= render "routines/routine_active_btn", routine: routine %>
       </div>
     </div>
+    
     <details class="collapse bg-gradient-to-tl from-teal-100 to-teal-50 items-center text-sm sm:text-base lg:text-lg">
       <summary class="collapse-title" id="tasks-display-btn-<%= routine.id %>">タスク一覧</summary>
       <ul class="collapse-content">

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -1,45 +1,57 @@
 <div id="routine-<%= routine.id %>">
-  <div class="border border-amber-300 p-3 my-5 mx-auto bg-gradient-to-tl from-amber-200/70 to-yellow-50/70 sm:w-11/12 md:w-9/12">
+  <div class="border border-green-400 rounded-lg p-3 my-5 mx-auto bg-green-100 w-11/12 md:w-9/12">
 
-    <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
-      <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-        <%= link_to "編集", edit_routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base",                                                                                   id: "edit-routine-btn-#{routine.id}" %>
-        <%= link_to "詳細", routine_path(routine), class: "min-h-10 btn bg-gradient-to-tl from-blue-300 to-blue-100 text-sm btn-sm sm:btn-md md:text-base",                                                                                          id: "show-routine-btn-#{routine.id}" %>
-        <%= link_to "削除", routine_path(routine), data: { turbo_method: :delete, turbo_confirm: "#{routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-sm sm:btn-md md:text-base", id: "delete-routine-btn-#{routine.id}" %>
+    <div class="items-center mb-3 sm:flex sm:justify-between sm:flex-wrap-reverse">
+      <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3">
+        <%= link_to "編集", edit_routine_path(routine), class: "btn-sm-custom btn-edit-custom",   id: "edit-routine-btn-#{routine.id}" %>
+        <%= link_to "詳細", routine_path(routine),      class: "btn-sm-custom btn-show-custom",   id: "show-routine-btn-#{routine.id}" %>
+        <%= link_to "削除", routine_path(routine),      class: "btn-sm-custom btn-delete-custom", id: "delete-routine-btn-#{routine.id}",
+                                                        data: { turbo_method: :delete, turbo_confirm: "#{routine.title}を削除してもよろしいですか？" }
+        %>
       </div>
-      <h1 class="break-words text-xl font-semibold border-b border-orange-200 my-2 sm:text-2xl md:text-3xl lg:text-4xl"><%= routine.title %></h1>
+
+      <!-- タイトル -->
+      <h1 class="text-title-custom"><%= routine.title %></h1>
     </div>
 
-    <div class="mb-5 mx-auto bg-gray-100/80 p-3 sm:p-5">
-      <p><%= routine.description %></p>
+    <!-- 説明文 (あれば表示) -->
+    <% if routine.description.present? %>
+      <div class="mb-3 border-gray-500 rounded-xl py-2 px-3 text-plane-custom">
+        <p><%= routine.description %></p>
+      </div>
+    <% end %>
+
+    <div class="flex justify-between mb-3">
+      <!-- 開始時間など -->
+      <div class="flex flex-col gap-2 sm:gap-1 text-plane-custom">
+        <p>
+          <span class="font-semibold">開始時間：</span><%= routine.start_time.strftime("%H:%M") if routine.start_time %>
+        </p>
+
+        <div id="total-estimated-time-for-routine-<%= routine.id %>">
+          <%= render "routines/routine_total_estimated_time", routine: routine %>
+        </div>
+
+        <p>
+          <span class="font-semibold">達成数　：</span><%= routine.completed_count %>
+        </p>
+      </div>
+
+      <!-- 投稿/実践ボタン -->
+      <div class="flex flex-col gap-2 sm:gap-1 sm:flex-row">
+        <div id="routine-post-btn-<%= routine.id %>">
+          <%= render "routines/routine_post_btn", routine: routine %>
+        </div>
+
+        <div id="routine-active-btn-<%= routine.id %>">
+          <%= render "routines/routine_active_btn", routine: routine %>
+        </div>
+      </div>
     </div>
 
-    <div class="mb-5 text-xs flex justify-between sm:justify-start sm:gap-5 sm:text-sm sm:mx-3 lg:text-base lg:gap-10">
-      <div>
-        <p>開始時間</p>
-        <%= routine.start_time.strftime("%H:%M") if routine.start_time %>
-      </div>
-
-      <div id="total-estimated-time-for-routine-<%= routine.id %>">
-        <%= render "routines/routine_total_estimated_time", routine: routine %>
-      </div>
-      <div>
-        <p>達成数</p>
-        <%= routine.completed_count %>
-      </div>
-    </div>
-
-    <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-      <div id="routine-post-btn-<%= routine.id %>">
-        <%= render "routines/routine_post_btn", routine: routine %>
-      </div>
-      <div id="routine-active-btn-<%= routine.id %>">
-        <%= render "routines/routine_active_btn", routine: routine %>
-      </div>
-    </div>
-    
-    <details class="collapse bg-gradient-to-tl from-teal-100 to-teal-50 items-center text-sm sm:text-base lg:text-lg">
-      <summary class="collapse-title" id="tasks-display-btn-<%= routine.id %>">タスク一覧</summary>
+    <!--タスク一覧-->
+    <details class="collapse collapse-plus shadow-md border border-gray-300 bg-gradient-to-tl from-teal-100 to-teal-50 hover:to-teal-100">
+      <summary class="collapse-title font-semibold min-h-1 p-[0.8rem] text-plane-custom" id="tasks-display-btn-<%= routine.id %>">タスク一覧</summary>
       <ul class="collapse-content">
         <%= render partial: "routines/task", collection: routine.tasks.includes(:tags), locals: { routine: routine, tags: tags } %>
       </ul>

--- a/app/views/routines/_routine_active_btn.html.erb
+++ b/app/views/routines/_routine_active_btn.html.erb
@@ -1,5 +1,11 @@
 <% if routine.is_active? %>
-  <p class="btn bg-gradient-to-tl from-gray-300 to-gray-100 border border-pink-300 text-sm md:text-base" id="active-now-<%= routine.id %>">実践中</p>
+  <p
+    class="bg-gradient-to-tl from-amber-300 to-amber-100 btn-md-custom" id="active-now-<%= routine.id %>">
+    実践中
+  </p>
 <% else %>
-  <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base", id: "active-btn-#{routine.id}" %>
+  <%= link_to "実践する", routines_active_path(routine), data: { turbo_method: :patch },
+    class: "bg-gradient-to-tl from-green-300 to-green-100 btn-md-custom",
+    id: "active-btn-#{routine.id}"
+  %>
 <% end %>

--- a/app/views/routines/_routine_post_btn.html.erb
+++ b/app/views/routines/_routine_post_btn.html.erb
@@ -1,5 +1,11 @@
 <% if routine.is_posted? %>
-  <%= link_to "投稿済み", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 text-sm md:text-base", id: "routine-unpost-btn-#{routine.id}" %>
+  <%= link_to "投稿済", routines_post_path(routine), data: { turbo_method: :patch },
+    class: "bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 btn-md-custom",
+    id: "routine-unpost-btn-#{routine.id}"
+    %>
 <% else %>
-  <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch }, class: "btn bg-gradient-to-tl from-green-300 to-green-100 text-sm md:text-base", id: "routine-post-btn-#{routine.id}" %>
+  <%= link_to "投稿する", routines_post_path(routine), data: { turbo_method: :patch },
+    class: "bg-gradient-to-tl from-green-300 to-green-100 btn-md-custom",
+    id: "routine-post-btn-#{routine.id}"
+  %>
 <% end %>

--- a/app/views/routines/_routine_post_btn.html.erb
+++ b/app/views/routines/_routine_post_btn.html.erb
@@ -1,6 +1,6 @@
 <% if routine.is_posted? %>
   <%= link_to "投稿済", routines_post_path(routine), data: { turbo_method: :patch },
-    class: "bg-gradient-to-tl from-gray-300 to-gray-100 border-pink-300 btn-md-custom",
+    class: "bg-gradient-to-tl from-gray-300 to-gray-100 border-green-300 btn-md-custom",
     id: "routine-unpost-btn-#{routine.id}"
     %>
 <% else %>

--- a/app/views/routines/_routine_total_estimated_time.html.erb
+++ b/app/views/routines/_routine_total_estimated_time.html.erb
@@ -1,12 +1,6 @@
-<div>
-  <p class="font-semibold">目安時間</p>
-  <span>
-    <%= routine.total_estimated_time[:hour] %> h
-  </span>
-  <span>
-    <%= routine.total_estimated_time[:minute] %> m
-  </span>
-  <span>
-    <%= routine.total_estimated_time[:second] %> s
-  </span>
-</div>
+<p>
+  <span class="font-semibold">目安時間：</span><span><%= routine.total_estimated_time[:hour]  %>h</span>
+                                             <span><%= routine.total_estimated_time[:minute] %>m</span>
+                                             <span><%= routine.total_estimated_time[:second] %>s</span>
+</p>
+

--- a/app/views/routines/_routine_total_estimated_time.html.erb
+++ b/app/views/routines/_routine_total_estimated_time.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <p>目安時間</p>
+  <p class="font-semibold">目安時間</p>
   <span>
     <%= routine.total_estimated_time[:hour] %> h
   </span>

--- a/app/views/routines/_routine_total_estimated_time.html.erb
+++ b/app/views/routines/_routine_total_estimated_time.html.erb
@@ -1,5 +1,5 @@
-<p>
-  目安時間：
+<div>
+  <p>目安時間</p>
   <span>
     <%= routine.total_estimated_time[:hour] %> h
   </span>
@@ -9,4 +9,4 @@
   <span>
     <%= routine.total_estimated_time[:second] %> s
   </span>
-</p>
+</div>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -1,22 +1,31 @@
 <li id="task_<%= task.id %>" class="list-group-item <%= task_arrange_class %>">
   <div class="border border-green-300 p-1 mb-3">
     <div class="flex justify-between items-center mb-5">
-      <h1 class="text-xs border-b border-cyan-300 font-semibold sm:text-sm md:text-base lg:text-lg"><%= task.title %></h1>
-      <div class="flex-none">
-        <button class="btn bg-gradient-to-tl from-green-300 hover:opacity-50 to-green-100 text-xs btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()" id="edit_task_btn_<%= task.id %>">編集</button>
-        <dialog id="edit_task_form_<%= task.id %>" class="modal">
-          <div class="modal-box">
-            <h1 class="text-center text-xl mb-10">タスク編集</h1>
-            <%= render partial: "routines/task_form", locals: { task: task, routine: routine, tags: tags } %>
-            <div class="modal-action">
-              <form method="dialog">
-                <button class="btn">キャンセル</button>
-              </form>
+
+      <h1 class="text-xs border-b border-cyan-300 font-semibold sm:text-sm md:text-base lg:text-lg">
+        <%= task.title %>
+      </h1>
+
+      <% unless request.path == routines_path %>
+        <!- タスクの編集/削除ボタン（ルーティン一覧では表示しない） -->
+        <div class="flex-none">
+          <button class="btn bg-gradient-to-tl from-green-300 hover:opacity-50 to-green-100 text-xs btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()" id="edit_task_btn_<%= task.id %>">編集</button>
+          <dialog id="edit_task_form_<%= task.id %>" class="modal">
+            <div class="modal-box">
+              <h1 class="text-center text-xl mb-10">タスク編集</h1>
+              <%= render partial: "routines/task_form", locals: { task: task, routine: routine, tags: tags } %>
+              <div class="modal-action">
+                <form method="dialog">
+                  <button class="btn">キャンセル</button>
+                </form>
+              </div>
             </div>
-          </div>
-        </dialog>
-        <%= link_to "削除", task_path(task), data: { turbo_method: :delete }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base", id: "task-delete-btn-#{task.id}" %>
-      </div>
+          </dialog>
+
+          <%= link_to "削除", task_path(task), data: { turbo_method: :delete }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base", id: "task-delete-btn-#{task.id}" %>
+        </div>
+      <% end %>
+
     </div>
 
     <div class="text-xs items-center sm:text-sm sm:flex sm:justify-between md:text-md lg:text-lg">

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -9,7 +9,7 @@
       <% unless request.path == routines_path %>
         <!- タスクの編集/削除ボタン（ルーティン一覧では表示しない） -->
         <div class="flex-none">
-          <button class="btn-sm-custom bg-gradient-to-tl from-green-300 to-green-100"
+          <button class="btn-sm-custom btn-edit-custom"
                   onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()"
                   id="edit_task_btn_<%= task.id %>"
           >
@@ -28,7 +28,7 @@
             </div>
           </dialog>
 
-          <%= link_to "削除", task_path(task), data: { turbo_method: :delete }, class: "btn bg-gradient-to-tl from-red-600 to-red-200 hover:opacity-50 text-xs btn-sm sm:btn-md md:text-base", id: "task-delete-btn-#{task.id}" %>
+          <%= link_to "削除", task_path(task), data: { turbo_method: :delete }, class: "btn-sm-custom btn-delete-custom", id: "task-delete-btn-#{task.id}" %>
         </div>
       <% end %>
 

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -9,7 +9,13 @@
       <% unless request.path == routines_path %>
         <!- タスクの編集/削除ボタン（ルーティン一覧では表示しない） -->
         <div class="flex-none">
-          <button class="btn bg-gradient-to-tl from-green-300 hover:opacity-50 to-green-100 text-xs btn-sm sm:btn-md md:text-base" onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()" id="edit_task_btn_<%= task.id %>">編集</button>
+          <button class="btn-sm-custom bg-gradient-to-tl from-green-300 to-green-100"
+                  onclick="document.querySelector('#edit_task_form_<%= task.id %>').showModal()"
+                  id="edit_task_btn_<%= task.id %>"
+          >
+            編集
+          </button>
+          
           <dialog id="edit_task_form_<%= task.id %>" class="modal">
             <div class="modal-box">
               <h1 class="text-center text-xl mb-10">タスク編集</h1>

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -1,6 +1,14 @@
-<div class="mt-5" id="routine-index-page">
-  <div class="text-end">
-    <%= link_to "ルーティンを作成する", new_routine_path, class:"btn bg-gradient-to-tl from-green-400 to-green-100 btn-md max-w-24 text-xs p-2 mr-2 sm:mr-5 sm:text-sm sm:max-w-40 md:max-w-48 md:mr-10 lg:btn-lg lg:max-w-60 lg:text-lg" %>
+<div id="routine-index-page" class="mt-5">
+
+  <div class="flex justify-between items-stretch px-2 mx-auto my-3 text-sm sm:w-9/12 md:text-lg">
+    <div class="basis-1/2 flex">
+      <%= link_to "←マイページ", my_pages_path, class: "text-green-600 hover:text-blue-400 hover:scale-110" %>
+    </div>
+
+    <div class="basis-1/2 flex justify-end gap-4">
+      <%= link_to "新規作成→", new_routine_path,    class: "text-green-600 hover:text-blue-400 hover:scale-110" %>
+      <%= link_to "投稿一覧→", routines_posts_path, class: "text-green-600 hover:text-blue-400 hover:scale-110" %>
+    </div>
   </div>
 
   <%= render 'routines/search_form', user_words: @user_words %>

--- a/app/views/routines/posts/index.html.erb
+++ b/app/views/routines/posts/index.html.erb
@@ -1,6 +1,12 @@
 <div class="mt-5">
-  <div class="text-end">
-    <%= link_to "ルーティンを投稿する", routines_path, class:"btn bg-gradient-to-tl from-green-400 to-green-100 btn-md max-w-24 text-xs p-2 mr-2 sm:mr-5 sm:text-sm sm:max-w-40 md:max-w-48 md:mr-10 lg:btn-lg lg:max-w-60 lg:text-lg" %>
+  <div class="flex justify-between items-stretch px-2 mx-auto my-3 text-sm sm:w-9/12 md:text-lg">
+    <div class="basis-1/2 flex">
+      <%= link_to "マイページ", my_pages_path, class: "hover:text-blue-400 hover:scale-110" %>
+    </div>
+
+    <div class="basis-1/2 flex justify-end">
+      <%= link_to "My ルーティン", routines_path, class: "hover:text-blue-400 hover:scale-110" %>
+    </div>
   </div>
 
   <%= render 'routines/search_form', user_words: @user_words %>

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -1,13 +1,13 @@
 <div class="p-3 mx-auto bg-green-50 rounded-lg w-11/12 md:w-9/12">
 
   <div class="flex gap-2 mb-5">
-    <%= link_to "<< ルーティン一覧", routines_path,
+    <%= link_to "←ルーティン一覧", routines_path,
       class: "btn text-xs bg-green-400 btn-sm min-h-9
               sm:min-w-28 sm:text-sm lg:btn-md
               hover:from-gray-300 hover:to-gray-300 hover:scale-105"
     %>
 
-    <%= link_to "<< マイページ", my_pages_path,
+    <%= link_to "←マイページ", my_pages_path,
       class: "btn text-xs bg-green-400 btn-sm min-h-9
               sm:min-w-28 sm:text-sm lg:btn-md
               hover:from-gray-300 hover:to-gray-300 hover:scale-105"

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -1,26 +1,35 @@
-<div class="p-3 my-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 md:w-9/12">
+<div class="p-3 mx-auto bg-green-50 rounded-lg w-11/12 md:w-9/12">
 
-  <%= link_to "一覧に戻る", routines_path,
-    class: "btn text-sm mb-5 bg-gradient-to-tl from-gray-300 to-gray-100 btn-md 
-            sm:text-base sm:min-w-28 md:mb-10"
-  %>
+  <div class="flex gap-2 mb-5">
+    <%= link_to "<< ルーティン一覧", routines_path,
+      class: "btn text-xs bg-green-400 btn-sm min-h-9
+              sm:min-w-28 sm:text-sm lg:btn-md
+              hover:from-gray-300 hover:to-gray-300 hover:scale-105"
+    %>
+
+    <%= link_to "<< マイページ", my_pages_path,
+      class: "btn text-xs bg-green-400 btn-sm min-h-9
+              sm:min-w-28 sm:text-sm lg:btn-md
+              hover:from-gray-300 hover:to-gray-300 hover:scale-105"
+    %>
+  </div>
   
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
-      <%= link_to "編集", edit_routine_path(@routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-md md:text-base", id: "routine-edit-btn-#{@routine.id}" %>
-      <%= link_to "削除", routine_path(@routine, from_path: request.path), data: { turbo_method: :delete, turbo_confirm: "#{@routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-md md:text-base", id: "routine-delete-btn-#{@routine.id}" %>
+      <%= link_to "編集", edit_routine_path(@routine), class: "min-h-10 btn bg-gradient-to-tl from-green-300 to-green-100 text-sm btn-sm sm:btn-md md:text-base hover:from-gray-300 hover:to-gray-300 hover:scale-105", id: "routine-edit-btn-#{@routine.id}" %>
+      <%= link_to "削除", routine_path(@routine, from_path: request.path), data: { turbo_method: :delete, turbo_confirm: "#{@routine.title}を削除してもよろしいですか？" }, class: "min-h-10 btn bg-gradient-to-tl from-red-600 to-red-200 text-sm btn-sm sm:btn-md md:text-base hover:from-gray-300 hover:to-gray-300 hover:scale-105", id: "routine-delete-btn-#{@routine.id}" %>
     </div>
 
-    <h1 class="break-words bg-gray-50/40 rounded-lg p-3 font-semibold my-2 text-2xl md:text-3xl lg:text-4xl"><%= @routine.title %></h1>
+    <h1 class="break-words bg-inherit rounded-lg p-3 font-semibold my-2 text-2xl md:text-3xl lg:text-4xl"><%= @routine.title %></h1>
   </div>
 
-  <div class="mb-5 mx-auto bg-gray-50/70 p-3 sm:p-5">
+  <div class="mb-5 mx-auto bg-white shadow-md rounded-lg p-3 sm:p-5 sm:mx-5">
     <p><%= @routine.description %></p>
   </div>
 
   <div class="mb-5 mx-3 text-sm flex flex-col gap-2 sm:flex-row sm:justify-between sm:justify-start sm:mx-5 sm:gap-5 lg:text-base lg:gap-10 lg:mx-16">
     <div>
-      <p>開始時間</p>
+      <p class="font-semibold">開始時間</p>
       <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %>
       （<%= I18n.t("activerecord.attributes.routine/notification.#{@routine.notification}") %>）
     </div>
@@ -30,12 +39,12 @@
     </div>
 
     <div>
-      <p>達成回数</p>
+      <p class="font-semibold">達成回数</p>
       <%= @routine.completed_count %>
     </div>
   </div>
   
-  <div class="text-center p-5 bg-gray-100">
+  <div class="text-center p-5 bg-inherit">
 
     <!-- タスク オートコンプリート -->
     <%= select_tag 'auto_complete',

--- a/app/views/routines/show.html.erb
+++ b/app/views/routines/show.html.erb
@@ -1,6 +1,9 @@
 <div class="p-3 my-5 mx-auto bg-gradient-to-tl from-sky-100/70 to-sky-50/70 w-11/12 md:w-9/12">
 
-  <%= link_to "一覧に戻る", routines_path, class:"btn text-sm mb-5 bg-gradient-to-tl from-gray-300 to-gray-100 btn-md sm:text-base sm:min-w-28 md:btn-lg md:mb-10" %>
+  <%= link_to "一覧に戻る", routines_path,
+    class: "btn text-sm mb-5 bg-gradient-to-tl from-gray-300 to-gray-100 btn-md 
+            sm:text-base sm:min-w-28 md:mb-10"
+  %>
   
   <div class="items-center mb-5 sm:flex sm:justify-between sm:flex-wrap-reverse">
     <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3 md:gap-5">
@@ -16,11 +19,20 @@
   </div>
 
   <div class="mb-5 mx-3 text-sm flex flex-col gap-2 sm:flex-row sm:justify-between sm:justify-start sm:mx-5 sm:gap-5 lg:text-base lg:gap-10 lg:mx-16">
-    <p>開始時間: <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %></p>
+    <div>
+      <p>開始時間</p>
+      <%= @routine.start_time.strftime("%H:%M") if @routine.start_time %>
+      （<%= I18n.t("activerecord.attributes.routine/notification.#{@routine.notification}") %>）
+    </div>
+    
     <div id="total-estimated-time-for-routine-<%= @routine.id %>">
       <%= render "routines/routine_total_estimated_time", routine: @routine %>
     </div>
-    <p>達成回数： <%= @routine.completed_count %></p>
+
+    <div>
+      <p>達成回数</p>
+      <%= @routine.completed_count %>
+    </div>
   </div>
   
   <div class="text-center p-5 bg-gray-100">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,17 @@
-<h1 class="text-center my-10 text-xl font-semibold sm:text-3xl lg:text-4xl">プロフィール編集</h1>
+<div class="sm:flex sm:justify-between mt-3 mb-10 sm:mt-5 mx-5 sm:mx-7">
+  <div class="flex sm:basis-3/12">
+    <%= link_to "<< 戻る", user_path(current_user),
+      class: "btn text-xs bg-gradient-to-tl from-green-500 to-green-500 btn-sm min-h-9 mb-3
+              sm:text-sm lg:btn-md
+              hover:from-gray-300 hover:to-gray-300 hover:scale-105"
+    %>
+  </div>
+
+  <h1 class="sm:basis-6/12 text-xl font-semibold text-center sm:text-3xl lg:text-4xl">プロフィール編集</h1>
+
+  <div class="sm:basis-3/12"></div>
+</div>
+
 
 <div class="text-center">
   <%= render "edit_form", user: @user %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="sm:flex sm:justify-between mt-3 sm:my-5 mx-5 sm:mx-7">
   <div class="flex sm:basis-3/12">
-    <%= link_to "<< マイページ", my_pages_path,
+    <%= link_to "←マイページ", my_pages_path,
       class: "btn text-xs bg-gradient-to-tl from-green-500 to-green-500 btn-sm min-h-9 mb-3
               sm:min-w-28 sm:text-sm lg:btn-md
               hover:from-gray-300 hover:to-gray-300 hover:scale-105"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,18 @@
-<h1 class="text-xl font-semibold my-5 text-center sm:text-3xl lg:text-4xl">プロフィール</h1>
+<div class="sm:flex sm:justify-between mt-3 sm:my-5 mx-5 sm:mx-7">
+  <div class="flex sm:basis-3/12">
+    <%= link_to "<< マイページ", my_pages_path,
+      class: "btn text-xs bg-gradient-to-tl from-green-500 to-green-500 btn-sm min-h-9 mb-3
+              sm:min-w-28 sm:text-sm lg:btn-md
+              hover:from-gray-300 hover:to-gray-300 hover:scale-105"
+    %>
+  </div>
+
+  <h1 class="sm:basis-6/12 text-xl font-semibold text-center sm:text-3xl lg:text-4xl">プロフィール</h1>
+
+  <div class="sm:basis-3/12"></div>
+</div>
+
+
 
 <div class="bg-gradient-to-tl from-cyan-200/60 to-cyan-0/60 rounded-lg w-11/12 mx-auto p-5 border border-sky-300 sm:w-9/12 sm:p-10 lg:w-8/12">
   <%= image_tag current_user.avatar.url, class: 'rounded-circle my-2 mx-auto', size: '200x200', id: "avatar-#{current_user.id}" %>
@@ -21,9 +35,5 @@
 
   <div class="text-center">
     <%= link_to "プロフィールを編集", edit_user_path(current_user), class: "btn bg-gradient-to-tl from-emerald-400 to-emerald-100 mb-5 btn-md min-w-28 md:text-lg md::btn-lg md:min-h-16 sm:min-w-40" %>
-  </div>
-
-  <div class="text-center">
-    <%= link_to "戻る", my_pages_path, class:"btn bg-gradient-to-tl from-gray-400 to-gray-100 mx-auto min-w-20 md:text-lg md:btn-lg sm:max-w-36" %>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,6 +17,9 @@ ja:
         start_time: 開始時間
         completed_count: 達成回数
         copied_count: コピー数
+      routine/notification:
+        line: LINE通知
+        "no": 通知オフ
       task:
         title: タイトル
         estimated_time_in_second: 目安時間

--- a/db/migrate/20241025074609_add_notification_to_routines.rb
+++ b/db/migrate/20241025074609_add_notification_to_routines.rb
@@ -1,0 +1,5 @@
+class AddNotificationToRoutines < ActiveRecord::Migration[7.0]
+  def change
+    add_column :routines, :notification, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_10_142010) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_25_074609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_142010) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "posted_at"
+    t.integer "notification", default: 0
     t.index ["user_id"], name: "index_routines_on_user_id"
   end
 

--- a/spec/system/index_routines_spec.rb
+++ b/spec/system/index_routines_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "RoutinesPaths", type: :system, js: true do
+RSpec.describe "Routines#index", type: :system, js: true do
   let!(:user)           { create(:user, :for_system_spec) }
   let!(:user_other)     { create(:user, :for_system_spec) }
   let!(:routine)        { create(:routine, user: user, title: 'ルーティン1') }
@@ -35,7 +35,7 @@ RSpec.describe "RoutinesPaths", type: :system, js: true do
     end
 
     it 'ルーティン作成画面に遷移できる' do
-      click_on 'ルーティンを作成する'
+      find("a[href='#{new_routine_path}']").click
       expect(page).to have_current_path(new_routine_path)
     end
 

--- a/spec/system/show_edit_users_spec.rb
+++ b/spec/system/show_edit_users_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "ShowEditUsers", type: :system do
       end
 
       it '「戻る」でマイページに遷移できる' do
-        click_on '戻る'
+        find("a[href='#{my_pages_path}']").click
         expect(page).to have_current_path(my_pages_path)
       end
     end

--- a/spec/system/show_edit_users_spec.rb
+++ b/spec/system/show_edit_users_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "ShowEditUsers", type: :system do
       end
 
       it '「戻る」でマイページに遷移できる' do
-        find("a[href='#{my_pages_path}']").click
+        click_on "←マイページ"
         expect(page).to have_current_path(my_pages_path)
       end
     end

--- a/spec/system/show_routines_spec.rb
+++ b/spec/system/show_routines_spec.rb
@@ -39,8 +39,13 @@ RSpec.describe "ShowRoutines", type: :system do
     end
 
     it 'ルーティン一覧画面に遷移できる' do
-      click_on '一覧に戻る'
+      find("a[href='#{routines_path}']")click
       expect(page).to have_current_path(routines_path)
+    end
+
+    it 'マイページに遷移できる' do
+      find("a[href='#{my_pages_path}']")click
+      expect(page).to have_current_path(my_pages_path)
     end
 
     describe 'Taskの作成処理', js: true do

--- a/spec/system/show_routines_spec.rb
+++ b/spec/system/show_routines_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "ShowRoutines", type: :system do
     end
 
     it 'ルーティン一覧画面に遷移できる' do
-      find("a[href='#{routines_path}']")click
+      click_on "←ルーティン一覧"
       expect(page).to have_current_path(routines_path)
     end
 

--- a/spec/system/show_routines_spec.rb
+++ b/spec/system/show_routines_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "ShowRoutines", type: :system do
     end
 
     it 'マイページに遷移できる' do
-      find("a[href='#{my_pages_path}']")click
+      click_on "←マイページ"
       expect(page).to have_current_path(my_pages_path)
     end
 


### PR DESCRIPTION
## 概要
- Routinesテーブルに通知方法を設定するカラムを追加
- tailwindのカスタムコンポーネントを設定するファイルを作成

## やったこと
- Routinesテーブルにnotificationカラムを追加
- notificationカラムはenumで管理
- LINE通知は、実践中のルーティンをLINE通知に設定しているユーザーのみを対象にするように変更
- UIを微修正

## 変更結果・スクショ
<img src="https://i.gyazo.com/9630e564390c843e3ccab7a5989cf0cc.png" width="400">

## 注意点
* [ ]

## できなかったこと
