### PR TITLE
Lineログイン時にメールアドレスを取得できるように修正

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -32,14 +32,4 @@ class OauthsController < ApplicationController
   def auth_params
     params.permit(:code, :provider, :error, :state, :friendship_status_changed)
   end
-
-  # 引数に渡した文字列からハッシュ値を生成する
-  def generate_digest_hash(letter)
-    Digest::SHA256.hexdigest(letter)
-  end
-
-  # 渡されたメールアドレスから、一意のメールアドレスを生成する
-  def generate_unique_email_address(email_address)
-    generate_digest_hash(email_address) + SecureRandom.uuid
-  end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -10,6 +10,7 @@ class OauthsController < ApplicationController
       
   def callback
     provider = auth_params[:provider]
+
     if @user = login_from(provider)
       redirect_to root_path, :notice => "ログインしました！"
     else
@@ -17,14 +18,9 @@ class OauthsController < ApplicationController
         # LINEから取得した情報でユーザーを新規作成する
         @user = create_from(provider)
 
-        # create_fromの時点では、emailカラムにLINEのuserIdが格納されている。
-        # 以下の処理でメールアドレスからLINEのuserIdが推測されないようにする。
-        unique_email = generate_unique_email_address(@user.email)
-        @user.update!(email: "#{unique_email}@email")
-
         reset_session
         auto_login(@user)
-        redirect_to user_path(@user), :notice => "ログインしました！ メールアドレスの編集を行なってください"
+        redirect_to my_pages_path, :notice => "ログインしました！"
       rescue
         redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
       end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -13,13 +13,13 @@ Rails.application.config.sorcery.configure do |config|
   config.external_providers = %i[line]
 
   # credentials.ymlの環境変数からLINEログイン用のチャネルのIDとシークレットを取得
-  config.line.key = Rails.application.credentials.dig(:line, :login_channel_id)
+  config.line.key    = Rails.application.credentials.dig(:line, :login_channel_id)
   config.line.secret = Rails.application.credentials.dig(:line, :login_channel_secret)
   # コールバックIDを設定
-  config.line.callback_url = Settings.sorcery[:line_callback_url]
-  config.line.scope = 'profile'
-  config.line.bot_prompt = 'aggressive' # LINEログイン時に公式アカウントを友だち追加
-  config.line.user_info_mapping = {name: 'displayName', email: 'userId'}
+  config.line.callback_url      = Settings.sorcery[:line_callback_url]
+  config.line.scope             = 'profile openid email'
+  config.line.bot_prompt        = 'aggressive' # LINEログイン時に公式アカウントを友だち追加
+  config.line.user_info_mapping = { name: 'displayName', email: 'email' }
 
   # -- core --
   # What controller action to call for non-authenticated users. You can also


### PR DESCRIPTION
## 概要
Lineログイン時にメールアドレスを取得できるように修正

## やったこと
- LINE DeveloppersでOpenConnectのメールアドレス取得権限の申請を行なった
- app/controllers/oauths_controller.rbのemail自動作成処理を削除
- config/initializers/sorcery.rbでscopeを'profile openid email'に変更

## 注意点
- 動作未確認

