### PR TITLE
Fix line

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -70,12 +70,12 @@ class OauthsController < ApplicationController
   end
 
   def update_user_email(email = nil)
-    if email
-      @user.email = email
-    else
+    if email == nil || User.find_by(email: email)
       @user.email = "morning-#{@user.id}@email.com"
+    else
+      @user.email = email
     end
-
+    
     @user.save!
   end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,5 +1,7 @@
 require 'securerandom'
 require 'digest'
+require 'net/http'
+require 'json'
 
 class OauthsController < ApplicationController
   skip_before_action :require_login, raise: false
@@ -15,14 +17,23 @@ class OauthsController < ApplicationController
       redirect_to root_path, :notice => "ログインしました！"
     else
       begin
-        # LINEから取得した情報でユーザーを新規作成する
-        @user = create_from(provider)
+        # providerから取得した情報でユーザーを新規作成する
+        @user = create_from(provider) # lineの場合、emailはuserIdのまま
 
+        # lineの場合、emailを変更する処理を実行
+        if provider == 'line'
+          id_token   = @access_token[:id_token]
+          uid        = @user_hash[:uid]
+          line_email = get_email_from_line(id_token, uid)
+          
+          update_user_email(line_email)
+        end
+        
         reset_session
         auto_login(@user)
         redirect_to my_pages_path, :notice => "ログインしました！"
       rescue
-        redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+        redirect_to root_path, :alert => "#{provider.titleize}でのログインに失敗しました。"
       end
     end
   end
@@ -31,5 +42,40 @@ class OauthsController < ApplicationController
 
   def auth_params
     params.permit(:code, :provider, :error, :state, :friendship_status_changed)
+  end
+
+  # Lineのid_tokenの検証を行い、レスポンスを受け取る
+  def get_email_from_line(id_token, uid)
+    uri  = URI.parse('https://api.line.me/oauth2/v2.1/verify')
+    head = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+    body = [
+             ['id_token' , id_token],
+             ['client_id', Rails.application.credentials.dig(:line, :login_channel_id)],
+             ['user_id'  , uid]
+           ]
+    # POSTリクエストを作成
+    req              = Net::HTTP::Post.new(uri.path, head)
+    req.body         = URI.encode_www_form(body)
+    # HTTPオブジェクトを作成
+    http             = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl     = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    # リクエストを送信し、レスポンスを取得
+    response = http.start { |http|
+      http.request(req)     
+    }
+    
+    response_body = JSON.parse(response.body)
+    email         = response_body['email']
+  end
+
+  def update_user_email(email = nil)
+    if email
+      @user.email = email
+    else
+      @user.email = "morning-#{@user.id}@email.com"
+    end
+
+    @user.save!
   end
 end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -19,7 +19,7 @@ Rails.application.config.sorcery.configure do |config|
   config.line.callback_url      = Settings.sorcery[:line_callback_url]
   config.line.scope             = 'profile openid email'
   config.line.bot_prompt        = 'aggressive' # LINEログイン時に公式アカウントを友だち追加
-  config.line.user_info_mapping = { name: 'displayName', email: 'email' }
+  config.line.user_info_mapping = { name: 'displayName', email: 'userId' }
 
   # -- core --
   # What controller action to call for non-authenticated users. You can also


### PR DESCRIPTION
## 概要
LINEログイン時に、LINEからユーザーのメールアドレス情報を取得するように修正

## やったこと
- LINE DeveloppersのLINEログイン用チャネルでメールアドレス取得申請を行なった
- LINEから取得するデータのscopeを'profile openid email'に変更した
- app/controllers/oauths_controller.rbのcallbackアクションを修正し、以下の処理を追加した
  - LINE API側から取得したOpenIDを検証し、そのレスポンスからユーザーのメールアドレスを取得する
