### PR TITLE
simplecovの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+/coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem "selenium-webdriver"
   # テスト用のダミーデータを作成
   gem 'faker'
+  gem 'simplecov', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     et-orbi (1.2.11)
@@ -383,6 +384,12 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 6, < 8)
       tilt (>= 1.4.0, < 3)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -465,6 +472,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-scheduler
+  simplecov
   sorcery
   spring-commands-rspec
   sprockets-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
 require 'selenium-webdriver'
+# カバレッジ起動
+require 'simplecov'
+SimpleCov.start
 
 # spec/support/配下のファイルを読み込み
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }


### PR DESCRIPTION
## 概要
テストコードのカバレッジを確認するためのgemを導入
## やったこと
- gem 'simplecov'をdevelopment, test環境にインストール
- spec/rails_helper.rbにsimplecovの導入と起動処理を記述
- gitignoreにcoverageディレクトリを追加
## 変更結果
<img src="https://i.gyazo.com/3864e8cfca507547a4bfd14ebea5c41a.png" width="500">