### PR TITLE
1クリックで新しいルーティンを作成する機能を実装

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -69,7 +69,7 @@
 }
 
 .text-plane-custom {
-  @apply text-xs md:text-sm text-gray-800;
+  @apply text-xs md:text-sm;
 }
 
 .text-md-custom {

--- a/app/controllers/guest_logins_controller.rb
+++ b/app/controllers/guest_logins_controller.rb
@@ -2,7 +2,7 @@ class GuestLoginsController < ApplicationController
   skip_before_action :require_login
 
   def create
-    random_value = SecureRandom.alphanumeric(10)
+    random_value = SecureRandom.alphanumeric(10) #ランダムな文字列を生成 => email, passwordに使用
 
     user = User.create!(
       name:                  "ゲストユーザー",
@@ -11,9 +11,10 @@ class GuestLoginsController < ApplicationController
       password_confirmation: random_value.to_s,
       role:                  "guest"
     )
-    login(user.email, random_value)
-    
     user.make_first_routine.make_first_task
+    user.create_quick_routine_template!
+
+    login(user.email, random_value)
 
     redirect_to my_pages_path, notice: "ゲストログインしました。"
   end

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -7,20 +7,24 @@ class Routines::PlaysController < ApplicationController
   def show
     @task = @tasks[session[:playing_task_num]]
     
-    # 最後のタスクの場合、turbo-frameリクエストを無効化
+    # 最後のタスクの場合は完了ページに遷移するため、turbo-frameリクエストを無効化
     @turbo_setting               = { turbo_method: :patch }
     @turbo_setting[:turbo_frame] = '_top' if session[:playing_task_num] == (@tasks.count - 1)
   end
 
   def create
-    session[:playing_task_num] = 0 # 次に実行するtaskの順番を管理
-    session[:experience_log]   = Hash.new # どのタグの経験値をどのくらい獲得したのかを管理
+    session[:playing_task_num] = 0        # 次に実行するtaskの順番を管理
+    session[:experience_log]   = Hash.new # どのタグの経験値をどのくらい獲得したのかを管理: {tag_id: exp}
+
     redirect_to play_path(@routine)
   end
 
   def update
     session[:playing_task_num] += 1
-    session[:experience_log]    = set_experience_log(session[:experience_log], params[:tag_ids]) if params[:tag_ids]
+
+    if params[:tag_ids]
+      session[:experience_log] = set_experience_log(session[:experience_log], params[:tag_ids])
+    end
 
     if session[:playing_task_num] >= @tasks.count
       @routine.complete_count
@@ -51,6 +55,6 @@ class Routines::PlaysController < ApplicationController
       experience_log[tag_id] ||= 0
       experience_log[tag_id]  += 1
     end
-    experience_log
+    experience_log # {tag_id: 獲得exp}
   end
 end

--- a/app/controllers/routines/quick_creates_controller.rb
+++ b/app/controllers/routines/quick_creates_controller.rb
@@ -1,0 +1,17 @@
+class Routines::QuickCreatesController < ApplicationController
+  def create
+    if current_user.quick_routine_template.nil?
+      current_user.create_quick_routine_template!
+    end
+
+    routine_template = current_user.quick_routine_template
+    new_routine      = current_user.routines.quick_build(routine_template)
+
+    if new_routine.save
+      redirect_to routine_path(new_routine), notice: "ルーティンを作成しました"
+    else
+      flash.now[:alert] = "ルーティンの作成に失敗しました"
+      render turbo_stream: turbo_stream.update('flash', partial: "shared/flash")
+    end
+  end
+end

--- a/app/controllers/routines/quick_creates_controller.rb
+++ b/app/controllers/routines/quick_creates_controller.rb
@@ -1,10 +1,6 @@
 class Routines::QuickCreatesController < ApplicationController
   def create
-    if current_user.quick_routine_template.nil?
-      current_user.create_quick_routine_template!
-    end
-
-    routine_template = current_user.quick_routine_template
+    routine_template = current_user.quick_routine_template || current_user.create_quick_routine_template!
     new_routine      = current_user.routines.quick_build(routine_template)
 
     if new_routine.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,10 +15,12 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_new_params)
     if @user.save
-      auto_login(@user)
+      # ユーザーの初期設定を行う
       @user.make_first_routine.make_first_task
-      flash[:notice] = 'ユーザーを新しく追加しました'
-      redirect_to my_pages_path
+      @user.create_quick_routine_template!
+
+      auto_login(@user)
+      redirect_to my_pages_path, notice: 'ユーザーを新しく追加しました'
     else
       flash.now[:alert] = 'ユーザーの作成に失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   end
 
   def task_arrange_class
-    request.path == routines_path ? '' : 'hover:bg-amber-100'
+    request.path == routines_path ? '' : 'hover:bg-amber-100 tooltip tooltip-success'
   end
 
   def feature_icon_class(reward, feature_reward)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
     when root_path, policy_path, terms_path
       return ''
     else
-      return 'pb-16 pt-1 h-full mx-auto bg-green-50/90 min-h-screen w-11/12 sm:w-4/5'
+      return 'pb-16 pt-1 h-full mx-auto bg-green-100/75 min-h-screen w-11/12 sm:w-4/5'
     end
   end
 

--- a/app/models/quick_routine_template.rb
+++ b/app/models/quick_routine_template.rb
@@ -1,0 +1,6 @@
+class QuickRoutineTemplate < ApplicationRecord
+  belongs_to :user
+
+  validates :title      , length: { maximum: 25  }, presence: true
+  validates :description, length: { maximum: 500 }
+end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -38,6 +38,16 @@ class Routine < ApplicationRecord
     self
   end
 
+  # クイック作成
+  def self.quick_build(template)
+    new_routine = self.new(
+                            title:       template.title,
+                            description: template.description,
+                            start_time:  template.start_time
+                          )
+    new_routine
+  end
+
   def total_estimated_time
     result          = second_to_time_string(all_task_estimated_time)
     result[:hour]   = "0#{result[:hour]}"   if result[:hour]   < 10

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,15 +3,16 @@ class User < ApplicationRecord
   
   authenticates_with_sorcery!
 
-  has_many   :routines            , dependent: :destroy
-  has_many   :user_tag_experiences, dependent: :destroy
-  has_many   :tags                , through:   :user_tag_experiences
-  has_many   :likes               , dependent: :destroy
-  has_many   :liked_routines      , through:   :likes, source: :routine
-  has_many   :authentications     , dependent: :destroy
-  has_many   :user_rewards        , dependent: :destroy
-  has_many   :rewards             , through:   :user_rewards
-  belongs_to :feature_reward      , class_name: 'Reward', foreign_key: 'feature_reward_id', optional: true
+  has_many   :routines               , dependent: :destroy
+  has_many   :user_tag_experiences   , dependent: :destroy
+  has_many   :tags                   , through:   :user_tag_experiences
+  has_many   :likes                  , dependent: :destroy
+  has_many   :liked_routines         , through:   :likes, source: :routine
+  has_many   :authentications        , dependent: :destroy
+  has_many   :user_rewards           , dependent: :destroy
+  has_many   :rewards                , through:   :user_rewards
+  has_one    :quick_routine_templates, dependent: :destroy
+  belongs_to :feature_reward         , class_name: 'Reward', foreign_key: 'feature_reward_id', optional: true
   
   accepts_nested_attributes_for :authentications
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
                      description: '「編集」からタスクの追加・編集をしましょう！',
                      is_active:   true
                     }
-    new_routine = routines.create!(routine_data)
+    routines.create!(routine_data)
   end
 
   # 取得していない称号の条件を1つ1つ確認し、条件を満たしていれば取得する処理

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many   :authentications        , dependent: :destroy
   has_many   :user_rewards           , dependent: :destroy
   has_many   :rewards                , through:   :user_rewards
-  has_one    :quick_routine_templates, dependent: :destroy
+  has_one    :quick_routine_template , dependent: :destroy
   belongs_to :feature_reward         , class_name: 'Reward', foreign_key: 'feature_reward_id', optional: true
   
   accepts_nested_attributes_for :authentications

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   def make_first_routine
     routine_data = { 
                      title:       "#{name}さんのルーティン",
-                     description: '「詳細」からタスクの追加や編集をしましょう！',
+                     description: '「編集」からタスクの追加・編集をしましょう！',
                      is_active:   true
                     }
     new_routine = routines.create!(routine_data)

--- a/app/views/routines/_add_task_btn.html.erb
+++ b/app/views/routines/_add_task_btn.html.erb
@@ -1,9 +1,8 @@
 <button class="btn bg-gradient-to-tl from-emerald-200 to-emerald-50 w-full text-center" onclick="task_form.showModal()"><span class="text-blue-500">＋</span>タスクを追加</button>
 <dialog id="task_form" class="modal">
   <div class="modal-box">
-    <h1 class="text-center text-xl mb-10">タスク新規作成</h1>
     <%= render "routines/task_form", task: task, routine: routine, tags: tags %>
-    <div class="modal-action">
+    <div class="modal-action mt-0">
       <form method="dialog">
         <button class="btn bg-gradient-to-tl from-gray-300 to-gray-100 btn-md">閉じる</button>
       </form>

--- a/app/views/routines/_edit_form.html.erb
+++ b/app/views/routines/_edit_form.html.erb
@@ -17,21 +17,21 @@
     <%= render 'shared/error_messages', object: f.object %>
 
     <!-- タイトルフォーム -->
-    <div class="mb-3">
+    <div class="mb-3 text-plane-custom">
       <%= f.label      :title, 'タイトル：' %>
-      <%= f.text_field :title, placeholder: 'タイトル(必須)', class: "input-form-custom w-full text-plane-custom" %>
+      <%= f.text_field :title, placeholder: 'タイトル(必須)', class: "input-form-custom w-full text-[10px] sm:text-sm" %>
     </div>
 
     <!-- descriptionフォーム -->
-    <div class="mb-3">
+    <div class="mb-3 text-plane-custom">
       <%= f.label :description, '説明文：' %>
-      <%= f.text_area :description, placeholder: "説明文（任意）", class: "textarea-sm-custom w-full text-title-custom" %>
+      <%= f.text_area :description, placeholder: "説明文（任意）", class: "textarea-sm-custom w-full text-[10px] sm:text-sm" %>
     </div>
 
     <!-- start_time -->
-    <div class="mb-3">
+    <div class="mb-3 text-plane-custom">
       <%= f.label      :start_time, '開始時間：' %>
-      <%= f.time_field :start_time, class: "time-form-sm-custom text-md-custom", min: "00:00", max: "23:59" %>
+      <%= f.time_field :start_time, class: "time-form-sm-custom w-7/12 sm:w-3/12", min: "00:00", max: "23:59" %>
     </div>
   <% end %>
 </div>

--- a/app/views/routines/_routine.html.erb
+++ b/app/views/routines/_routine.html.erb
@@ -3,7 +3,7 @@
 
     <div class="items-center mb-3 sm:flex sm:justify-between sm:flex-wrap-reverse">
       <div class="flex justify-end gap-1 mb-3 sm:order-last sm:ml-auto sm:gap-3">
-        <%= link_to "編集", routine_path(routine),      class: "btn-sm-custom btn-show-custom",   id: "show-routine-btn-#{routine.id}", data: {turbo_frame: '_top'} %>
+        <%= link_to "編集", routine_path(routine),      class: "btn-sm-custom btn-edit-custom",   id: "show-routine-btn-#{routine.id}", data: {turbo_frame: '_top'} %>
         <%= link_to "削除", routine_path(routine),      class: "btn-sm-custom btn-delete-custom", id: "delete-routine-btn-#{routine.id}",
                                                         data: { turbo_method: :delete, turbo_confirm: "#{routine.title}を削除してもよろしいですか？" }
         %>

--- a/app/views/routines/_search_form.html.erb
+++ b/app/views/routines/_search_form.html.erb
@@ -1,6 +1,6 @@
 <div class="my-3" id="search-container">
   <%= form_with url: request.path, method: :get do |f| %>
-    <div class="w-3/4 mx-auto">
+    <div class="w-9/12 mx-auto">
 
       <!-- 検索フォーム -->
       <div class="flex justify-center">

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -18,9 +18,8 @@
           
           <dialog id="edit_task_form_<%= task.id %>" class="modal">
             <div class="modal-box">
-              <h1 class="text-center text-xl mb-10">タスク編集</h1>
               <%= render partial: "routines/task_form", locals: { task: task, routine: routine, tags: tags } %>
-              <div class="modal-action">
+              <div class="modal-action mt-0">
                 <form method="dialog">
                   <button class="btn">キャンセル</button>
                 </form>

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -1,4 +1,4 @@
-<li id="task_<%= task.id %>" class="list-group-item tooltip tooltip-success list-item <%= task_arrange_class %>" data-tip="ドラッグ&ドロップで並べ替え">
+<li id="task_<%= task.id %>" class="list-group-item list-item <%= task_arrange_class %>" data-tip="ドラッグ&ドロップで並べ替え">
   <div class="task-zone-custom mb-3">
     <div class="flex justify-between items-center mb-1">
 

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -2,17 +2,20 @@
   <%= form_with model: task, url: task.new_record? ? routine_tasks_path(routine) : task_path(task), class: "text-center" do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
 
-    <div class="mb-5 md:mb-10" id="<%= task_form_id(task) %>">
+    <div class="my-5 md:mb-10" id="<%= task_form_id(task) %>">
       <%= f.label :title,
                   "タイトル:",
                   class: "mb-2 font-medium text-lg sm:text-xl md:font-semibold"
       %>
       <br>
 
-      <%= f.text_field :title,
-          class: "min-h-10 w-10/12 p-2 mx-auto border border-gray-300 rounded-lg
-                  md:text-xl hover:border-gray-500"
-      %>
+      <div class="tooltip tooltip-info block" data-tip="タイトル（25 文字以内）">
+        <%= f.text_field :title,
+            class: "min-h-10 w-10/12 p-2 mx-auto border border-gray-300 rounded-lg
+                    md:text-xl hover:border-gray-500"
+        %>
+      </div>
+      
 
       <!-- オートコンプリート -->
       <div class="w-10/12 mx-auto max-h-40 overflow-y-auto" id="task-title-options-zone-<%= task_form_id(task) %>">
@@ -31,17 +34,17 @@
       </div>
     </div>
 
-    <div class="flex flex-wrap gap-4">
+    <div class="flex flex-wrap gap-4 mb-5">
       <% tags.each do |tag| %>
-        <div class="flex-none">
-          <%= f.label "tag_ids_#{tag.id}" do %>
-            <%= f.check_box :tag_ids, { multiple: true, include_hidden: false }, tag.id, tag.is_on_task?(task) %>
-            <%= tag.name %>
+        <div class="flex-none form-control">
+          <%= f.label "tag_checkbox_#{tag.id}_#{task_form_id(task)}", class: "label cursor-pointer" do %>
+            <%= f.check_box :tag_ids, { multiple: true, include_hidden: false, class: "checkbox checkbox-accent", id: "task_tag_checkbox_#{tag.id}_#{task_form_id(task)}" }, tag.id, tag.is_on_task?(task) %>
+            <span class="label-text"><%= tag.name %></span>
           <% end %>
         </div>
       <% end %>
     </div>
 
-    <%= f.submit nil, class:"btn bg-gradient-to-tl from-green-300 to-green-100 mb-5 btn-md min-w-28 mx-auto sm:btn-lg sm:text-lg lg:min-w-64 lg-text-xl" %>
+    <%= f.submit nil, class:"btn-xl-custom btn-create-custom px-10 mb-5 min-w-28 mx-auto" %>
   <% end %>
 </div>

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -15,7 +15,12 @@
   <%= render 'routines/search_form', user_words: @user_words %>
 
   <div class="w-9/12 mx-auto flex justify-end">
-    <%= link_to '1 clickで作成', routines_quick_creates_path, data: {turbo_method: :post, tip: "ルーティンを作成できます"}, class: "btn-md-custom btn-create-custom tooltip tooltip-accent" %>
+    <%= link_to '1 clickで作成',
+      routines_quick_creates_path,
+      data: {turbo_method: :post, tip: "ルーティンを作成できます"},
+      class: "btn-md-custom btn-create-custom tooltip tooltip-accent",
+      id: "quick-create-routine-btn"
+    %>
   </div>
   
   

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -13,6 +13,11 @@
 <div id="routine-index-page" class="">
 
   <%= render 'routines/search_form', user_words: @user_words %>
+
+  <div class="w-9/12 mx-auto flex justify-end">
+    <%= link_to '1 clickで作成', routines_quick_creates_path, data: {turbo_method: :post, tip: "ルーティンを作成できます"}, class: "btn-md-custom btn-create-custom tooltip tooltip-accent" %>
+  </div>
+  
   
   <%= turbo_frame_tag "routine-index-field", autoscroll: true do %>
     <% if @routines.empty? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,13 @@ Rails.application.routes.draw do
     resources :plays, only: %i[create update show], param: :routine_id, module: :routines, shallow: true
   end
 
+  # URLが"routines/**"の形式では、RoutinesコントローラのshowアクションのURLとして認識されてしまうため、pathオプションを"routine"に指定
   namespace :routines, path: 'routine' do
-    resources :actives, only: %i[update], param: :routine_id
-    resources :posts, only: %i[index update], param: :routine_id
-    resources :finishes, only: %i[index]
-    resources :likes, only: %i[create destroy], param: :routine_id
+    resources :actives      , only: %i[update]        , param: :routine_id
+    resources :posts        , only: %i[index update]  , param: :routine_id
+    resources :finishes     , only: %i[index]
+    resources :likes        , only: %i[create destroy], param: :routine_id
+    resources :quick_creates, only: %i[create]
   end
 
   namespace :tasks do

--- a/db/migrate/20241207183706_create_quick_routine_templates.rb
+++ b/db/migrate/20241207183706_create_quick_routine_templates.rb
@@ -1,0 +1,12 @@
+class CreateQuickRoutineTemplates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :quick_routine_templates do |t|
+      t.references :user       , null: false, foreign_key: true
+      t.string     :title      , null: false, default: "new ルーティン"
+      t.string     :description
+      t.time       :start_time , default: "07:00:00"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_28_203942) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_07_183706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_28_203942) do
     t.index ["routine_id"], name: "index_likes_on_routine_id"
     t.index ["user_id", "routine_id"], name: "index_likes_on_user_id_and_routine_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "quick_routine_templates", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", default: "new ルーティン", null: false
+    t.string "description"
+    t.time "start_time", default: "2000-01-01 07:00:00"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_quick_routine_templates_on_user_id"
   end
 
   create_table "rewards", force: :cascade do |t|
@@ -127,6 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_28_203942) do
 
   add_foreign_key "likes", "routines"
   add_foreign_key "likes", "users"
+  add_foreign_key "quick_routine_templates", "users"
   add_foreign_key "routines", "users"
   add_foreign_key "task_tags", "tags"
   add_foreign_key "task_tags", "tasks"

--- a/spec/factories/quick_routine_template.rb
+++ b/spec/factories/quick_routine_template.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :quick_routine_template do
+    association :user
+
+    trait :over_length do
+      title       { Faker::Lorem.characters(number: 26) }
+      description { Faker::Lorem.characters(number: 501) }
+    end
+  end
+end

--- a/spec/models/quick_routine_template_spec.rb
+++ b/spec/models/quick_routine_template_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe QuickRoutineTemplate, type: :model do
+  describe 'バリデーション' do
+    context '正常な値' do
+      it 'QuickRoutineTemplateを作成できる' do
+        quick_routine_template = create(:quick_routine_template)
+        expect(quick_routine_template).to        be_valid
+        expect(quick_routine_template.errors).to be_empty
+      end
+    end
+
+    context "不正な値" do
+      it 'titleは必須' do
+        quick_routine_template = build(:quick_routine_template, title: nil)
+        expect(quick_routine_template).not_to            be_valid
+        expect(quick_routine_template.errors[:title]).to eq ['を入力してください']
+      end
+
+      it 'titleは25字以内、説明文は500字以内' do
+        quick_routine_template = build(:quick_routine_template, :over_length)
+        expect(quick_routine_template).to                      be_invalid
+        expect(quick_routine_template.errors[:title]).to       eq ['は25文字以内で入力してください']
+        expect(quick_routine_template.errors[:description]).to eq ['は500文字以内で入力してください']
+      end
+    end
+  end
+
+  describe 'アソシエーション' do
+    describe 'User:QuickRoutineTemplate = 1:N' do
+      let!(:user)                   { create(:user) }
+      let!(:quick_routine_template) { create(:quick_routine_template, user: user) }
+
+      it '適切に設定されている' do
+        expect(user.quick_routine_template).to eq quick_routine_template
+      end
+    end
+  end
+
+  describe 'DB制約' do
+    describe 'デフォルト値' do
+      let!(:quick_routine_template) { create(:quick_routine_template) }
+
+      it '適切に設定されている' do
+        expect(quick_routine_template.title).to      eq 'new ルーティン'
+      end
+    end
+
+    describe 'NOT NULL' do
+      it 'titleカラム' do
+        quick_routine_template = build(:quick_routine_template, title: nil)
+        expect{ quick_routine_template.save(validate: false) }.to raise_error ActiveRecord::NotNullViolation
+      end
+    end
+  end
+
+  # describe 'スコープ' do
+  # end
+
+  # describe 'インスタンスメソッド' do
+  # end
+
+  # describe 'クラスメソッド' do
+  # end
+end

--- a/spec/system/routines_index_spec.rb
+++ b/spec/system/routines_index_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Routines#index", type: :system, js: true do
   end
 
   context 'ログイン後' do
-
     before do
       login_as(user)
       visit routines_path
@@ -51,12 +50,36 @@ RSpec.describe "Routines#index", type: :system, js: true do
         expect(@routines_container).to have_content 'ルーティンがありません ルーティンを作成しましょう！！'
       end
 
-      it '検索フォームが表示' do
+      it '検索フォームとクイック作成ボタンが表示' do
         expect(@routines_container).to have_selector '#user_words'
         expect(@routines_container).to have_selector '#search-btn'
         expect(@routines_container).to have_selector '#column'
         expect(@routines_container).to have_selector '#direction'
         expect(@routines_container).to have_selector '#filter_target'
+        expect(@routines_container).to have_selector '#quick-create-routine-btn'
+      end
+
+      describe '1clickでルーティンを作成する機能' do
+        let!(:quick_routine_template) { create(:quick_routine_template, user: user) }
+
+        it 'ルーティンを1clickで作成できる' do
+          routine_size_prev = user.routines.count
+          find('#quick-create-routine-btn').click
+          sleep 0.1
+          routine_size_new = user.routines.count
+          new_routine      = user.routines.last
+          new_routine_id   = new_routine.id
+          #View
+          expect(page).to have_current_path routine_path(new_routine_id)
+          expect(page).to have_content 'ルーティンを作成しました'
+          #DB
+          expect(routine_size_new).to eq routine_size_prev + 1
+          expect(new_routine).to have_attributes(
+                                                  title:        quick_routine_template.title,
+                                                  description:  quick_routine_template.description,
+                                                  start_time:   quick_routine_template.start_time
+                                                )
+        end
       end
     end
 

--- a/spec/system/routines_show_spec.rb
+++ b/spec/system/routines_show_spec.rb
@@ -163,8 +163,8 @@ RSpec.describe "ShowRoutines", type: :system, js: true do
       let!(:hour_form)       { find('#task_hour') }
       let!(:minute_form)     { find('#task_minute') }
       let!(:second_form)     { find('#task_second') }
-      let!(:tag1_check_box) { find("input[id='task_tag_ids_#{tag1.id}']") }
-      let!(:tag2_check_box) { find("input[id='task_tag_ids_#{tag2.id}']") }
+      let!(:tag1_check_box) { find("input[id='task_tag_checkbox_#{tag1.id}_new']") }
+      let!(:tag2_check_box) { find("input[id='task_tag_checkbox_#{tag2.id}_new']") }
 
       it 'フォームが表示されている' do
         #各フォーム
@@ -178,8 +178,8 @@ RSpec.describe "ShowRoutines", type: :system, js: true do
         expect(second_form.value).to eq '00'
         # タグのセレクトボックス
         Tag.all.each do |tag|
-          tag_cont = find("label[for='task_tag_ids_#{tag.id}']")
-          expect(tag_cont).to have_selector "input[id='task_tag_ids_#{tag.id}']"
+          tag_cont = find("label[for='task_tag_checkbox_#{tag.id}_new']")
+          expect(tag_cont).to have_selector "input[id='task_tag_checkbox_#{tag.id}_new']"
           expect(tag_cont).to have_content  tag.name
         end
       end
@@ -239,7 +239,7 @@ RSpec.describe "ShowRoutines", type: :system, js: true do
           #フォーム
           minute_form = find('#task_minute') #ページ更新後の要素を再取得
           expect(minute_form.value).to eq                 '00'
-          expect(task_form_new).to     have_checked_field "task_tag_ids_#{tag1.id}"
+          expect(task_form_new).to     have_checked_field "task_tag_checkbox_#{tag1.id}_new"
           #DB
           expect(task_size_prev).to eq routine.tasks.size
           expect(task_tags_prev).to eq TaskTag.all.size
@@ -257,8 +257,8 @@ RSpec.describe "ShowRoutines", type: :system, js: true do
       let!(:hour_form)      { find('#task_hour')                          }
       let!(:minute_form)    { find('#task_minute')                        }
       let!(:second_form)    { find('#task_second')                        }
-      let!(:tag1_check_box) { find("input[id='task_tag_ids_#{tag1.id}']") }
-      let!(:tag2_check_box) { find("input[id='task_tag_ids_#{tag2.id}']") }
+      let!(:tag1_check_box) { find("input[id='task_tag_checkbox_#{tag1.id}_#{task.id}']") }
+      let!(:tag2_check_box) { find("input[id='task_tag_checkbox_#{tag2.id}_#{task.id}']") }
 
       context '正しい値を入力' do
         # 前提: task.tagsは tag1のみ
@@ -304,7 +304,7 @@ RSpec.describe "ShowRoutines", type: :system, js: true do
           title_form = find("#task_title")
           expect(task_form).to        have_content       'タイトルを入力してください'
           expect(title_form.value).to eq                 ''
-          expect(task_form).to        have_checked_field "task_tag_ids_#{tag2.id}"
+          expect(task_form).to        have_checked_field "task_tag_checkbox_#{tag2.id}_#{task.id}"
           # DB
           task.reload
           expect(task.title).not_to eq      ''


### PR DESCRIPTION
## 概要
1クリックで新しいルーティンを作成する機能を実装

## やったこと
- QuickRoutineTemplateモデルを作成
  - カラム
    - title
    - description
    - start_time
- User:QuickRoutineTemplate = 1:1 となるアソシエーションを設定
- Routine::QuickCreatesコントローラを作成
  - createアクション
- views/routines/index.html.erbにルーティンのクイック作成ボタンを配置
- テストコードを作成