### PR TITLE
新しい称号を5つ追加

### DIFF
--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -85,7 +85,7 @@ class RoutinesController < ApplicationController
     all_task_names = []
 
     current_user.routines.includes(:tasks).each do |routine|
-      all_task_names.concat routine.tasks.pluck(:title)
+      all_task_names.concat(routine.tasks.pluck(:title))
     end
 
     all_task_names.uniq

--- a/app/javascript/auto_complete_task.js
+++ b/app/javascript/auto_complete_task.js
@@ -32,13 +32,13 @@ function isFormsChanged(titleForms) {
 function taskTitleAutoComplete(titleForms) {
   const titleOptions = document.querySelectorAll('#all-task-names option');    // セレクトボックス内のoption要素をすべて取得
 
-  if (titleOptions.length === 0) return;
+  if (titleOptions?.length === 0) return;
 
   // 各タイトルフォームに対してイベントリスナーを設定
   for (let titleForm of titleForms) {
     let formParent = titleForm.parentElement;
     
-    // バリデーションエラーの場合、祖父母要素を取得する
+    // バリデーションエラーの場合、'field_with_errors'クラスのdivに囲まれるので、その親要素を取得する
     if (formParent.classList.contains('field_with_errors')) {
       formParent = formParent.parentElement;
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,31 +80,8 @@ class User < ApplicationRecord
   end
 
   private
-
-  def reward_achieve?(reward)
-    condition = reward.condition
-    send(condition.to_sym)
-  end
-
-# --- 称号の条件 ---
-  def completed_routine_1?
-    complete_routines_count >= 1
-  end
-
-  def completed_routines_3?
-    complete_routines_count >= 3
-  end
-
-  def get_experiences_10?
-    user_tag_experiences.total_experience_points >= 10
-  end
-
-  def post_routine_1?
-    routines.posted.size >= 1
-  end
-
-# --- Level UP ---
-  # レベルアップするかどうかを判定
+  # --- Level UP ---
+  #レベルアップするかどうかを判定
   def require_level_up?(total_exp)
     exp_to_level_up = cal_exp_to_level_up
 
@@ -127,5 +104,47 @@ class User < ApplicationRecord
   def level_up
     self.level += 1
     save!
+  end
+
+  # 称号獲得処理
+  def reward_achieve?(reward)
+    condition = reward.condition
+    send(condition.to_sym)
+  end
+# --- 称号の条件 ---
+  def completed_routine_1?
+    complete_routines_count >= 1
+  end
+
+  def completed_routines_3?
+    complete_routines_count >= 3
+  end
+
+  def completed_routines_10?
+    complete_routines_count >= 10
+  end
+
+  def completed_routines_30?
+    complete_routines_count >= 30
+  end
+
+  def get_experiences_10?
+    user_tag_experiences.total_experience_points >= 10
+  end
+
+  def better_myself_exp_10?
+    Tag.find_by(name: "自己投資").user_tag_experiences.where(user_id: id).total_experience_points >= 10
+  end
+
+  def post_routine_1?
+    routines.posted.size >= 1
+  end
+
+  def level_5?
+    level >= 5
+  end
+
+  def level_10?
+    level >= 10
   end
 end

--- a/app/views/routines/_task_form.html.erb
+++ b/app/views/routines/_task_form.html.erb
@@ -2,19 +2,18 @@
   <%= form_with model: task, url: task.new_record? ? routine_tasks_path(routine) : task_path(task), class: "text-center" do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
 
-    <div class="my-5 md:mb-10" id="<%= task_form_id(task) %>">
+    <div class="my-5 md:mb-10 tooltip tooltip-success block" id="<%= task_form_id(task) %>" data-tip="25文字以内">
       <%= f.label :title,
                   "タイトル:",
                   class: "mb-2 font-medium text-lg sm:text-xl md:font-semibold"
       %>
+      
       <br>
 
-      <div class="tooltip tooltip-info block" data-tip="タイトル（25 文字以内）">
-        <%= f.text_field :title,
-            class: "min-h-10 w-10/12 p-2 mx-auto border border-gray-300 rounded-lg
-                    md:text-xl hover:border-gray-500"
-        %>
-      </div>
+      <%= f.text_field :title,
+          class: "min-h-10 w-10/12 p-2 mx-auto border border-gray-300 rounded-lg
+                  md:text-xl hover:border-gray-500"
+      %>
       
 
       <!-- オートコンプリート -->

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,28 +15,56 @@ if Tag.all.size == 0
   end
 end
 
-if Reward.all.size == 0
-  Reward.create!(
-    name: "はじまりの一歩！",
-    condition: "completed_routine_1?",
-    description: "ルーティンを1回クリアする"
-  )
+Reward.find_or_create_by!(
+  name: "はじまりの一歩！",
+  condition: "completed_routine_1?",
+  description: "ルーティンを1回クリアする"
+)
 
-  Reward.create!(
-    name: "小さな達成者",
-    condition: "completed_routines_3?",
-    description: "ルーティンを3回クリアする"
-  )
+Reward.find_or_create_by!(
+  name: "小さな達成者",
+  condition: "completed_routines_3?",
+  description: "ルーティンを3回クリアする"
+)
 
-  Reward.create!(
-    name: "若葉の成長",
-    condition: "get_experiences_10?",
-    description: "経験値を10獲得する"
-  )
+Reward.find_or_create_by!(
+  name: "若葉の成長",
+  condition: "get_experiences_10?",
+  description: "経験値を10獲得する"
+)
 
-  Reward.create!(
-    name: "朝の森の案内人",
-    condition: "post_routine_1?",
-    description: "ルーティンを1つ投稿する"
-  )
-end
+Reward.find_or_create_by!(
+  name: "朝の森の案内人",
+  condition: "post_routine_1?",
+  description: "ルーティンを1つ投稿する"
+)
+
+Reward.find_or_create_by!(
+  name: "未来の賢者",
+  condition: "level_5?",
+  description: "レベル5以上に達する"
+)
+
+Reward.find_or_create_by!(
+  name: "朝の英雄",
+  condition: "level_10?",
+  description: "レベル10以上に達する"
+)
+
+Reward.find_or_create_by!(
+  name: "コツコツマスター",
+  condition: "better_myself_exp_10?",
+  description: "自己投資の経験値を合計10以上獲得する"
+)
+
+Reward.find_or_create_by!(
+  name: "朝の冒険家",
+  condition: "completed_routines_10?",
+  description: "ルーティンを10回クリアする"
+)
+
+Reward.find_or_create_by!(
+  name: "幸運の猫大福",
+  condition: "completed_routines_30?",
+  description: "ルーティンを30回クリアする"
+)


### PR DESCRIPTION
## 概要
称号を5つ追加 + テスト

## やったこと
- 新しい称号を5つ追加
- 称号の獲得条件の判定処理をuserモデルに追加
- /db/seed.rbファイルに新しい称号のデータを追加
- 称号獲得条件の判定処理のテストをspec/models/user_spec.rbに追加

## 注意事項
* [ ] 本番環境で、adminの称号管理画面から称号画像を設定する
* [ ] 本番環境でrails db:seedコマンドを実行

## 変更結果
<img src="https://i.gyazo.com/64825ccddd44c4808b49e6c5fc10235a.jpg" width="400">