### PR TITLE
FIX: お問い合わせフォームのバグ修正＋通知ジョブのバグ修正

### DIFF
--- a/app/jobs/set_notification_job.rb
+++ b/app/jobs/set_notification_job.rb
@@ -8,7 +8,7 @@ class SetNotificationJob < ApplicationJob
     User.includes(:authentications).find_each do |user|
       active_routine = user.routines.find_by(is_active: true)
 
-      next if active_routine.nil? || user.notification.off? || !start_time?(active_routine.start_time, time_now)
+      next if active_routine.nil? || user.off? || !start_time?(active_routine.start_time, time_now)
 
       case user.notification
       when 'line'

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -30,7 +30,7 @@
           <span class="text-red-500">*</span>
           件名
         <% end %>
-        <%= f.select :subject, @subjects_array.map { |key| I18n.t("activerecord.attributes.contact.subjects.#{key}") }, {}, { class: "select select-bordered select-sm w-8/12 lg:w-1/2" } %>
+        <%= f.select :subject, @subjects_array.map { |key| [ I18n.t("activerecord.attributes.contact.subjects.#{key}"), key] }, {}, { class: "select select-bordered select-sm w-8/12 lg:w-1/2" } %>
       </div>
 
       <div class="mb-5">


### PR DESCRIPTION
## 問題点
- 通知ジョブでUndifinedMethodError off?が出力されていた
- お問い合わせフォームで、件名のセレクトボックスからenumの日本語化した文字列がパラメータに渡っていた

## 変更内容
- "user.notification.off?" の記述を" user.off? "に修正
- 件名のセレクトボックスに渡す配列を["日本語化した件名", "subjectカラムの値"]を要素にもつ配列に変更

