### PR TITLE
QuickRoutineTemplateの編集機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,8 @@ class ApplicationController < ActionController::Base
 
   # routines/playsコントローラで生成したsessionを削除
   def playing_task_sesison_reset
-    session[:playing_task_num] = nil if session[:playing_task_num]
-    session[:experiene_log]    = nil if session[:experiene_log]
+    session[:task_index] = nil if session[:task_index]
+    session[:exp_log]    = nil if session[:exp_log]
   end
 
   def guest_block

--- a/app/controllers/quick_routine_templates_controller.rb
+++ b/app/controllers/quick_routine_templates_controller.rb
@@ -1,0 +1,26 @@
+class QuickRoutineTemplatesController < ApplicationController
+  before_action :is_create_template
+
+  def edit
+    @quick_routine_template = current_user.quick_routine_template
+  end
+
+  def update
+    @quick_routine_template = current_user.quick_routine_template
+
+    redirect_to routines_path, notice: '1click作成用テンプレートを更新しました' if @quick_routine_template.update(quick_routine_template_params)
+  end
+
+  private
+
+  def quick_routine_template_params
+    params.require(:quick_routine_template).permit(:title, :description, :start_time)
+  end
+
+  # Routineテンプレートがない場合作成
+  def is_create_template
+    return if current_user.quick_routine_template
+
+    current_user.create_quick_routine_template!
+  end
+end

--- a/app/controllers/quick_routine_templates_controller.rb
+++ b/app/controllers/quick_routine_templates_controller.rb
@@ -1,10 +1,6 @@
 class QuickRoutineTemplatesController < ApplicationController
   before_action :is_create_template
 
-  def edit
-    @quick_routine_template = current_user.quick_routine_template
-  end
-
   def update
     @quick_routine_template = current_user.quick_routine_template
 

--- a/app/controllers/routines/actives_controller.rb
+++ b/app/controllers/routines/actives_controller.rb
@@ -1,10 +1,12 @@
 class Routines::ActivesController < ApplicationController
   def update
-    @routine            = current_user.routines.find(params[:routine_id])
-    @routine_active_now = current_user.routines.find_by(is_active: true)
-    return if @routine == @routine_active_now
+    @routine = current_user.routines.find(params[:routine_id])
+    return if @routine.is_active?
 
+    # 元々activeだったルーティンを非アクティブ化
+    @routine_active_now = current_user.routines.find_by(is_active: true)
     @routine_active_now&.update!(is_active: false)
+
     @routine.update!(is_active: true)
   end
 end

--- a/app/controllers/routines/finishes_controller.rb
+++ b/app/controllers/routines/finishes_controller.rb
@@ -4,39 +4,33 @@ class Routines::FinishesController < ApplicationController
 
   def index
     current_user.add_complete_routines_count
+
     # 経験値情報をuser_tag_experiencesテーブルに保存
-    user_get_tag_experiences(session[:experience_log])
+    current_user.get_experiences(session[:exp_log])
+
     # レベルアップ処理
     flash.now[:notice] = 'レベルアップしました！！' if current_user.level_up_check
 
-    @tag_point_hash = make_tag_point_hash(session[:experience_log])
+    @tag_point_hash = make_tag_point_hash(session[:exp_log])
   end
 
   private
 
   # routines_playsコントローラを介さずにアクセスできない
   def block_if_no_session
-    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
+    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:task_index].nil?
   end
 
-  # 獲得した経験値情報から、UserTagExperiencesテーブルに情報を追加していく
-  def user_get_tag_experiences(experience_log)
-    experience_log.each do |tag_id, point|
-      UserTagExperience.create!(user_id: current_user.id, tag_id: tag_id.to_i, experience_point: point.to_i)
-    end
-  end
-
-  # { Tag名: 獲得Exp }を作成
-  # viewでどのタグの経験値をどのくらい獲得したかを表示するために使用。
-  def make_tag_point_hash(experience_log)
+  # viewで「どのタグの経験値をどのくらい獲得したか」表示する
+  def make_tag_point_hash(exp_log)
     tag_point_hash = {}
-    tags_hash      = Tag.all.index_by(&:id) # key=id, value=Tagモデルインスタンスとなるハッシュを作成。ハッシュにしてクエリ削減
+    tags_hash      = Tag.all.index_by(&:id) # { id: Tagモデルインスタンス, ... } ハッシュを作成。ハッシュにしてクエリ削減
 
-    experience_log.each do |tag_id, point|
+    exp_log.each do |tag_id, point|
       tag                      = tags_hash[tag_id.to_i]
       tag_point_hash[tag.name] = point
     end
 
-    tag_point_hash
+    tag_point_hash # { Tag名: 獲得Exp }
   end
 end

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -1,58 +1,59 @@
 class Routines::PlaysController < ApplicationController
   before_action      :block_if_no_session       , only: %i[show update]
-  before_action      :set_routine
-  before_action      :set_tasks                 , only: %i[show update]
+  before_action      :set_routine_and_tasks     , only: %i[show update]
   skip_before_action :playing_task_sesison_reset
 
   def show
-    @task = @tasks[session[:playing_task_num]]
-
-    # 最後のタスクの場合は完了ページに遷移するため、turbo-frameリクエストを無効化
-    @turbo_setting               = { turbo_method: :patch }
-    @turbo_setting[:turbo_frame] = '_top' if session[:playing_task_num] == (@tasks.size - 1)
+    set_task_and_turbo_options
   end
 
   def create
-    session[:playing_task_num] = 0  # 次に実行するtaskの順番を管理
-    session[:experience_log]   = {} # どのタグの経験値をどのくらい獲得したのかを管理: {tag_id: exp}
+    session[:task_index] = 0  # 次に実行するtaskの順番を管理
+    session[:exp_log]    = {} # どのタグの経験値をどのくらい獲得したのかを管理: {tag_id: exp}
 
-    redirect_to play_path(@routine)
+    redirect_to play_path(params[:routine_id])
   end
 
   def update
-    session[:playing_task_num] += 1
+    session[:task_index] += 1
+    session[:exp_log]     = set_exp_log(session[:exp_log], params[:tag_ids]) if params[:tag_ids]
 
-    session[:experience_log] = set_experience_log(session[:experience_log], params[:tag_ids]) if params[:tag_ids]
-
-    if session[:playing_task_num] >= @tasks.size
+    if session[:task_index] >= @tasks.size
       @routine.complete_count
       redirect_to routines_finishes_path
     else
-      redirect_to play_path(@routine)
+      set_task_and_turbo_options
+      render :show
     end
   end
 
   private
 
-  def set_routine
+  def set_routine_and_tasks
     @routine = current_user.routines.find(params[:routine_id])
+    @tasks   = @routine.tasks
   end
 
-  def set_tasks
-    @tasks = @routine.tasks
+  def set_task_and_turbo_options
+    @task          = @tasks[session[:task_index]] # 取り組むTask
+    @turbo_options = { turbo_method: :patch }
+
+    # 最後のタスクの場合は完了ページに遷移するため、turbo-frameリクエストを無効化
+    @turbo_options[:turbo_frame] = '_top' if session[:task_index] == (@tasks.size - 1)
   end
 
   # createアクションを介さないアクセスを拒否
   def block_if_no_session
-    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:playing_task_num].nil?
+    redirect_to my_pages_path, alert: 'ページに遷移できませんでした' if session[:task_index].nil?
   end
 
   # タグidと達成した回数を経験値管理ハッシュに格納する
-  def set_experience_log(experience_log, tag_ids)
+  def set_exp_log(exp_log, tag_ids)
     tag_ids.each do |tag_id|
-      experience_log[tag_id] ||= 0
-      experience_log[tag_id]  += 1
+      exp_log[tag_id] ||= 0
+      exp_log[tag_id]  += 1
     end
-    experience_log # {tag_id: 獲得exp}
+
+    exp_log # {"tag_id": 獲得exp}
   end
 end

--- a/app/controllers/routines/posts_controller.rb
+++ b/app/controllers/routines/posts_controller.rb
@@ -27,12 +27,21 @@ class Routines::PostsController < ApplicationController
   def set_order_query
     @column     = params[:column]
     @direction  = params[:direction]
-    @order_list = [['投稿日', nil], ['コピー数', 'copied_count']]
+    @order_list = [
+      ['投稿日'  , nil],
+      ['コピー数', 'copied_count']
+    ]
   end
 
   def set_filter_target
     @filter_target  = params[:filter_target]
-    @filter_options = [['すべて', nil], ['自分の投稿', 'my_post'], ['お気に入り', 'liked'], ['公式の投稿', 'official'], ['ユーザーの投稿', 'general']]
+    @filter_options = [
+      ['すべて'       , nil],
+      ['自分の投稿'   , 'my_post'],
+      ['お気に入り'   , 'liked'],
+      ['公式の投稿'   , 'official'],
+      ['ユーザーの投稿', 'general']
+    ]
   end
   # rubocop:enable Style/WordArray
 end

--- a/app/controllers/routines/quick_creates_controller.rb
+++ b/app/controllers/routines/quick_creates_controller.rb
@@ -4,6 +4,7 @@ class Routines::QuickCreatesController < ApplicationController
     new_routine      = current_user.routines.quick_build(routine_template)
 
     if new_routine.save
+      new_routine.make_first_task
       redirect_to routine_path(new_routine), notice: 'ルーティンを作成しました'
     else
       flash.now[:alert] = 'ルーティンの作成に失敗しました'

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -30,6 +30,7 @@ class RoutinesController < ApplicationController
     if @routine.save
       redirect_to routine_path(@routine), notice: '作成したルーティンにタスクを追加しましょう！'
     else
+      @quick_routine_template = current_user.quick_routine_template
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -8,6 +8,7 @@ class RoutinesController < ApplicationController
     @routines           = current_user.routines.search(params[:user_words]).custom_filter(@filter_target, current_user.id).includes(tasks: :tags).sort_routine(@column, @direction).page(params[:page])
     @user_words         = params[:user_words]
     @auto_complete_list = current_user.routines.make_routine_autocomplete_list
+    @quick_routine_template = current_user.quick_routine_template
   end
 
   def show
@@ -18,7 +19,8 @@ class RoutinesController < ApplicationController
   end
 
   def new
-    @routine = Routine.new
+    @routine                = Routine.new
+    @quick_routine_template = current_user.quick_routine_template
   end
 
   def create

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,6 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
+      @user.create_quick_routine_template! unless @user.quick_routine_template
       flash[:notice] = 'ログインしました！'
       redirect_to my_pages_path
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,12 +33,6 @@ module ApplicationHelper
   def task_arrange_class
     request.path == routines_path ? '' : 'hover:bg-amber-100 tooltip tooltip-success'
   end
-
-  def feature_icon_class(reward, feature_reward)
-    return 'i-uiw-star-off text-gray-500' if feature_reward.nil?
-
-    reward.id == feature_reward.id ? 'i-uiw-star-on text-red-500' : 'i-uiw-star-off text-gray-500'
-  end
   # --------------------------------------------------------
 
   def task_form_id(task)

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -17,9 +17,11 @@ class Routine < ApplicationRecord
   scope :liked,    ->(user_id)  { joins(:likes).where(likes: { user_id: }) }
 
   def make_first_task
-    task = tasks.create!(title: '水を飲む')
-    tag  = Tag.find_by(name: '日課')
-    task.tags << tag
+    self.class.transaction do
+      task = tasks.create!(title: '水を飲む')
+      tag  = Tag.find_by(name: '日課')
+      task.tags << tag
+    end
   end
 
   # Routineのコピー

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,10 +41,8 @@ class User < ApplicationRecord
       is_active:   true
     }
 
-    self.class.transaction do
-      new_routine = routines.create!(routine_params)
-      new_routine.make_first_task
-    end
+    new_routine = routines.create!(routine_params)
+    new_routine.make_first_task
   end
 
   # 取得していない称号の条件を1つ1つ確認し、条件を満たしていれば取得する処理

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,16 @@ class User < ApplicationRecord
     cal_exp_to_level_up - user_tag_experiences.total_experience_points
   end
 
+  # exp_log = { "tag_id": exp, ... }
+  def get_experiences(exp_log)
+    exp_log.each do |tag_id, exp|
+      user_tag_experiences.create!(
+        tag_id:           tag_id.to_i,
+        experience_point: exp
+      )
+    end
+  end
+
   # lineアカウントと連携しているか
   def link_line?
     !authentications.where(provider: 'line').empty?

--- a/app/views/quick_routine_templates/_edit_form.html.erb
+++ b/app/views/quick_routine_templates/_edit_form.html.erb
@@ -1,0 +1,32 @@
+<div class="border border-green-500 rounded-lg shadow-lg p-5" id="quick-routine-template-edit-form">
+  <div class="text-center mb-5">
+    <h3 class="text-lg-custom">ルーティンテンプレート編集</h3>
+    <p class="text-gray-700 text-sm-custom">1clickで作成するルーティンの情報を変更できます</p>
+  </div>
+
+  <%= form_with model: quick_routine_template do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+
+    <!-- タイトルフォーム -->
+    <div class="mb-3 text-plane-custom">
+      <%= f.label      :title, 'タイトル：' %>
+      <%= f.text_field :title, placeholder: 'タイトル(必須)', class: "input-form-custom w-full text-[10px] sm:text-sm" %>
+    </div>
+
+    <!-- descriptionフォーム -->
+    <div class="mb-3 text-plane-custom">
+      <%= f.label :description, '説明文：' %>
+      <%= f.text_area :description, placeholder: "説明文（任意）", class: "textarea-sm-custom w-full text-[10px] sm:text-sm" %>
+    </div>
+
+    <!-- start_time -->
+    <div class="mb-3 text-plane-custom">
+      <%= f.label      :start_time, '開始時間：' %>
+      <%= f.time_field :start_time, class: "time-form-sm-custom w-7/12 sm:w-3/12", min: "00:00", max: "23:59" %>
+    </div>
+
+    <div class="mb-3 text-plane-custom text-center">
+      <%= f.submit '更新', class: "btn btn-md-custom btn-create-custom w-5/12 sm:btn-wide" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/quick_routine_templates/update.turbo_stream.erb
+++ b/app/views/quick_routine_templates/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace 'quick-routine-template-edit-form' do %>
+  <%= render 'quick_routine_templates/edit_form', quick_routine_template: @quick_routine_template %>
+<% end %>

--- a/app/views/rewards/_reward_card.html.erb
+++ b/app/views/rewards/_reward_card.html.erb
@@ -7,17 +7,10 @@
       </button>
     <% end %> 
   </figure>
-  
+
   <!-- 称号タイトル -->
   <div class="card-body items-center text-center p-2">
-    <div class="tooltip tooltip-primary" data-tip="clickでプロフィールに設定">
-      <%= button_to users_feature_reward_path(current_user), { method: :patch, params: { user: { feature_reward_id: reward.id } } } do %>
-        <h2 class="text-reward-custom text-lg-custom flex items-center">
-          <i class="<%= feature_icon_class(reward, feature_reward) %>"></i>
-          <%= reward.name %>
-        </h2>
-      <% end %>
-    </div>
+    <%= render 'rewards/reward_title', reward: reward %>
   </div>
 </div>
 

--- a/app/views/rewards/_reward_title.html.erb
+++ b/app/views/rewards/_reward_title.html.erb
@@ -1,0 +1,20 @@
+<!-- プロフィールに設定されている -->
+<% if current_user.feature_reward_id == reward.id %>
+  <h2 class="text-reward-custom text-lg-custom flex items-center">
+    <i class="i-uiw-star-on text-red-500"></i>
+    <%= reward.name %>
+  </h2>
+
+<!-- 設定されていない -->
+<% else %>
+  <div class="tooltip tooltip-primary" data-tip="clickでプロフィールに設定">
+    <%= button_to users_feature_reward_path(current_user),
+        { method: :patch, params: { user: { feature_reward_id: reward.id } } } do
+    %>
+      <h2 class="text-reward-custom text-lg-custom flex items-center">
+        <i class="i-uiw-star-off text-gray-500"></i>
+        <%= reward.name %>
+      </h2>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/routines/_add_task_btn.html.erb
+++ b/app/views/routines/_add_task_btn.html.erb
@@ -1,5 +1,9 @@
 <button class="btn bg-gradient-to-tl from-emerald-200 to-emerald-50 w-full text-center" onclick="task_form.showModal()"><span class="text-blue-500">＋</span>タスクを追加</button>
 <dialog id="task_form" class="modal">
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+
   <div class="modal-box">
     <%= render "routines/task_form", task: task, routine: routine, tags: tags %>
     <div class="modal-action mt-0">

--- a/app/views/routines/_task.html.erb
+++ b/app/views/routines/_task.html.erb
@@ -17,6 +17,10 @@
           </button>
           
           <dialog id="edit_task_form_<%= task.id %>" class="modal">
+            <form method="dialog" class="modal-backdrop">
+              <button>close</button>
+            </form>
+
             <div class="modal-box">
               <%= render partial: "routines/task_form", locals: { task: task, routine: routine, tags: tags } %>
               <div class="modal-action mt-0">

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -15,12 +15,7 @@
   <%= render 'routines/search_form', user_words: @user_words %>
 
   <div class="w-9/12 mx-auto flex justify-end">
-    <%= link_to '1 clickで作成',
-      routines_quick_creates_path,
-      data: {turbo_method: :post, tip: "ルーティンを作成できます"},
-      class: "btn-md-custom btn-create-custom tooltip tooltip-accent",
-      id: "quick-create-routine-btn"
-    %>
+    <%= render 'shared/quick_routine_create_btn' %>
   </div>
   
   

--- a/app/views/routines/index.html.erb
+++ b/app/views/routines/index.html.erb
@@ -15,7 +15,7 @@
   <%= render 'routines/search_form', user_words: @user_words %>
 
   <div class="w-9/12 mx-auto flex justify-end">
-    <%= render 'shared/quick_routine_create_btn' %>
+    <%= render 'shared/quick_routine_create_btn', quick_routine_template: @quick_routine_template %>
   </div>
   
   

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -15,7 +15,7 @@
   <h1 class="page-title-custom">ルーティン新規作成</h1>
 
   <div class="w-8/12 lg:w-7/12 mx-auto flex justify-end">
-    <%= render 'shared/quick_routine_create_btn' %>
+    <%= render 'shared/quick_routine_create_btn', quick_routine_template: @quick_routine_template %>
   </div>
   
   <div class="text-center">

--- a/app/views/routines/new.html.erb
+++ b/app/views/routines/new.html.erb
@@ -15,12 +15,7 @@
   <h1 class="page-title-custom">ルーティン新規作成</h1>
 
   <div class="w-8/12 lg:w-7/12 mx-auto flex justify-end">
-    <%= link_to '1 clickで作成',
-      routines_quick_creates_path,
-      data: {turbo_method: :post, tip: "ルーティンを作成できます"},
-      class: "btn-md-custom btn-create-custom tooltip tooltip-accent",
-      id: "quick-create-routine-btn"
-    %>
+    <%= render 'shared/quick_routine_create_btn' %>
   </div>
   
   <div class="text-center">

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -43,12 +43,12 @@
 
     <div class="flex justify-center gap-2 mx-auto flex-col w-4/12">
       <%= link_to "達成", play_path(@routine, tag_ids: @task.tag_ids),
-          data: @turbo_setting,
+          data: @turbo_options,
           class: "btn-xl-custom btn-next-custom"
       %>
 
       <%= link_to "スキップ", play_path(@routine),
-          data: @turbo_setting,
+          data: @turbo_options,
           class: "btn-xl-custom btn-skip-custom"
       %>
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div class="bg-red-400 w-10/12 p-2 mt-3 rounded-lg mx-auto text-xs items-center sm:text-sm md:text-base lg:w-8/12">
+  <div class="bg-red-400 w-10/12 p-2 mt-3 mb-5 rounded-lg mx-auto text-xs items-center sm:text-sm md:text-base lg:w-8/12">
     <p class="font-semibold mb-3">入力エラー</p>
     <ul>
       <% object.errors.full_messages.each do |msg| %>

--- a/app/views/shared/_quick_routine_create_btn.html.erb
+++ b/app/views/shared/_quick_routine_create_btn.html.erb
@@ -19,7 +19,7 @@
 
   <div class="modal-box">
     <%= render 'quick_routine_templates/edit_form',
-        quick_routine_template: current_user.quick_routine_template %>
+        quick_routine_template: quick_routine_template %>
 
     <div class="modal-action">
       <form method="dialog">

--- a/app/views/shared/_quick_routine_create_btn.html.erb
+++ b/app/views/shared/_quick_routine_create_btn.html.erb
@@ -1,0 +1,30 @@
+<div class="flex items-center">
+  <%= link_to '1 clickで作成',
+      routines_quick_creates_path,
+      data: {turbo_method: :post, tip: "ルーティンを作成できます"},
+      class: "btn-md-custom btn-create-custom tooltip tooltip-accent",
+      id: "quick-create-routine-btn"
+  %>
+
+  <button class="btn btn-md-custom btn-ghost" onclick="quick_routine_template_form_modal.showModal()">
+    <i class="i-uiw-edit"></i>
+  </button>
+</div>
+
+<!-- Modal 編集フォーム -->
+<dialog id="quick_routine_template_form_modal" class="modal">
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+
+  <div class="modal-box">
+    <%= render 'quick_routine_templates/edit_form',
+        quick_routine_template: current_user.quick_routine_template %>
+
+    <div class="modal-action">
+      <form method="dialog">
+        <button class="btn btn-md-custom btn-cancel-custom">キャンセル</button>
+      </form>
+    </div>
+  </div>
+</dialog>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
   resources :my_pages       , only: %i[index]
   resources :rewards        , only: %i[index]
+  resources :quick_routine_templates, only: %i[update]
 
   get    'login',            to: 'user_sessions#new'
   post   'login',            to: 'user_sessions#create'

--- a/spec/system/routines_index_spec.rb
+++ b/spec/system/routines_index_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe "Routines#index", type: :system, js: true do
 
       describe '1clickでルーティンを作成する機能' do
         let!(:quick_routine_template) { create(:quick_routine_template, user: user) }
+        
+        before do
+          create(:tag, name: "日課")
+        end
 
         it 'ルーティンを1clickで作成できる' do
           routine_size_prev = user.routines.count


### PR DESCRIPTION
## 概要
- コードの修正
- モーダルUIの修正
- QuickRoutineTemplateの編集フォームを追加

## やったこと
- QuickRoutineTemplateの編集フォームをモーダルで追加
- Taskフォームのモーダルについて、モーダル外部をクリックしても閉じるように修正
- quick_routine_templatesコントローラを作成
  - updateアクションを追加

## 変更結果
<img src="https://i.gyazo.com/0b86828d02990f31bee47f930f76903f.jpg" width="400">