### PR TITLE
週間レポート作成機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,11 @@
  </tr>
  <tr>
   <td>フレームワーク</td>
-  <td>RubyonRails ver7.1</td>
+  <td>RubyonRails ver7.0</td>
  </tr>
  <tr>
   <td>インフラ</td>
-  <td>Heroku, AWS S3, Redis(Heroku addon), PostgresSQL(Heroku addon)</td>
- </tr>
- <tr>
-  <td>その他の使用技術</td>
-  <td>docker git github</td>
+  <td>Heroku, AWS S3, Redis(Heroku addon)</td>
  </tr>
  <tr>
   <td>認証</td>
@@ -157,8 +153,16 @@
   <td>テスト</td>
   <td>rspec, rubocop</td>
  </tr>
+ <tr>
+  <td>バッチ処理</td>
+  <td>sidekiq</td>
+ </tr>
+ <tr>
+  <td>その他の使用技術</td>
+  <td>docker git github</td>
+ </tr>
 </table>
 
-■ ER図(MVP時点)
+■ ER図
 ---
 <img src="https://i.gyazo.com/1df4fe72dc925df221f6b69bb707c86e.png">

--- a/app/controllers/routines/copies_controller.rb
+++ b/app/controllers/routines/copies_controller.rb
@@ -1,5 +1,4 @@
 class Routines::CopiesController < ApplicationController
-  before_action :guest_block, only: %i[create]
 
   def create
     routine_origin = Routine.includes(tasks: :tags).find(params[:routine_id])

--- a/app/controllers/routines/finishes_controller.rb
+++ b/app/controllers/routines/finishes_controller.rb
@@ -4,6 +4,9 @@ class Routines::FinishesController < ApplicationController
 
   def index
     current_user.add_complete_routines_count
+    # AchievedRecordに追加
+    routine = Routine.find(params[:routine_id])
+    current_user.achieve_records.create!(routine_id: routine.id, routine_title: routine.title)
 
     # 経験値情報をuser_tag_experiencesテーブルに保存
     current_user.get_experiences(session[:exp_log])

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -20,7 +20,7 @@ class Routines::PlaysController < ApplicationController
 
     if session[:task_index] >= @tasks.size
       @routine.complete_count
-      redirect_to routines_finishes_path
+      redirect_to routine_finishes_path
     else
       set_task_and_turbo_options
       render :show

--- a/app/jobs/concerns/line_text_push_request.rb
+++ b/app/jobs/concerns/line_text_push_request.rb
@@ -1,0 +1,36 @@
+require 'active_support'
+require 'net/http'
+require 'uri'
+require 'json'
+
+module LineTextPushRequest
+  extend ActiveSupport::Concern
+
+  # LINE Push通知のエンドポイントにPOSTリクエストを送信し、レスポンスを取得
+  def request_line_push_end_point(uid, text)
+    # エンドポイントへのPOSTリクエストを作成
+    uri = URI.parse('https://api.line.me/v2/bot/message/push')
+    req = Net::HTTP::Post.new(uri)
+    # リクエストヘッダの作成
+    req.content_type     = 'application/json'
+    req['Authorization'] = "Bearer #{Rails.application.credentials.channel_token}"
+    # リクエストボディの作成
+    req.body = make_request_body_json(uid, text)
+    # エンドポイントにrequestを送信（返り値はレスポンス）
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
+  end
+
+  private
+
+  # リクエストボディの情報を作成
+  def make_request_body_json(uid, text)
+    body_hash = {
+                  to:       uid,
+                  messages: [type: 'text', text: text]
+                }
+
+    JSON.generate(body_hash)
+  end
+end

--- a/app/jobs/line_notification_job.rb
+++ b/app/jobs/line_notification_job.rb
@@ -1,38 +1,15 @@
-require 'net/http'
-require 'uri'
-require 'json'
-
 class LineNotificationJob < ApplicationJob
   queue_as :default
   sidekiq_options retry: false # Jobが失敗した際、再試行せず破棄
   include Rails.application.routes.url_helpers
+  include LineTextPushRequest
 
   def perform(uid)
-    post_response_from_end_point(uid)
-  end
-
-  private
-
-  # LINEプロバイダーのエンドポイントにPOSTリクエストを送信し、レスポンスを取得する
-  def post_response_from_end_point(uid)
-    # エンドポイントへのPOSTリクエストを作成
-    uri     = URI.parse('https://api.line.me/v2/bot/message/push')
-    request = Net::HTTP::Post.new(uri)
-    # リクエストヘッダ・ボディを作成
-    request.content_type     = 'application/json'
-    request['Authorization'] = "Bearer #{Rails.application.credentials.channel_token}"
-    body_hash = {
-      to: uid,
-      messages: [
-        type: 'text',
-        text: "おはようございます！\n今日もモーニングルーティンを実践しましょう！！\n#{auth_at_provider_url(provider: :line, host: Settings.url.host)}"
-      ]
-    }
-    request.body = JSON.generate(body_hash)
-
-    # エンドポイントにrequestを送信
-    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-      http.request(request)
-    end
+    # 通知するText
+    text = "おはようございます！\n
+            今日もモーニングルーティンを実践しましょう！！\n\n
+            #{auth_at_provider_url(provider: :line, host: Settings.url.host)}"
+    # プッシュ通知を送信
+    request_line_push_end_point(uid, text)
   end
 end

--- a/app/jobs/line_notification_job.rb
+++ b/app/jobs/line_notification_job.rb
@@ -4,11 +4,14 @@ class LineNotificationJob < ApplicationJob
   include Rails.application.routes.url_helpers
   include LineTextPushRequest
 
-  def perform(uid)
+  def perform(user)
     # 通知するText
     text = "おはようございます！\n
             今日もモーニングルーティンを実践しましょう！！\n\n
             #{auth_at_provider_url(provider: :line, host: Settings.url.host)}"
+
+    uid  = user.authentications.find_by(provider: 'line').uid
+
     # プッシュ通知を送信
     request_line_push_end_point(uid, text)
   end

--- a/app/jobs/line_weekly_report_job.rb
+++ b/app/jobs/line_weekly_report_job.rb
@@ -11,11 +11,11 @@ class LineWeeklyReportJob < ApplicationJob
     achieve_routines_size = achieve_records.size # ルーティン達成数
     routine_titles        = achieve_records.pluck(:routine_title) # 達成したルーティンのタイトル一覧
 
-    text = "今週の週間レポートです！\n\n"
-      + "獲得経験値： #{total_exps}\n\n"
-      + "　　達成数： #{achieve_routines_size}\n"
-      + make_routine_titles_str(routine_titles)
-      + "来週も頑張りましょう！！"
+    text =  "今週の週間レポートです！\n\n"
+    text << "獲得経験値： #{total_exps}\n"
+    text << "　　達成数： #{achieve_routines_size}\n\n"
+    text << make_routine_titles_str(routine_titles)
+    text << "\n来週も頑張りましょう！！"
 
     uid  = user.authentications.find_by(provider: 'line').uid
 

--- a/app/jobs/line_weekly_report_job.rb
+++ b/app/jobs/line_weekly_report_job.rb
@@ -5,10 +5,11 @@ class LineWeeklyReportJob < ApplicationJob
   include LineTextPushRequest
 
   def perform(user, now)
-    total_exps            = user.user_tag_experiences.weekly(now).pluck(:experience_point).sum # 獲得経験値の合計, N+1
-    achieve_records       = user.achieve_records
-    achieve_routines_size = achive_records.size # ルーティン達成数
-    routine_titles        = achive_records.pluck(:routine_title) # 達成したルーティンのタイトル一覧
+    # whereで絞り込んでいるため、weeklyの処理でN+1問題
+    total_exps            = user.user_tag_experiences.weekly(now).pluck(:experience_point).sum # 獲得経験値の合計
+    achieve_records       = user.achieve_records.weekly(now)
+    achieve_routines_size = achieve_records.size # ルーティン達成数
+    routine_titles        = achieve_records.pluck(:routine_title) # 達成したルーティンのタイトル一覧
 
     text = "今週の週間レポートです！\n\n"
       + "獲得経験値： #{total_exps}\n\n"

--- a/app/jobs/line_weekly_report_job.rb
+++ b/app/jobs/line_weekly_report_job.rb
@@ -1,0 +1,37 @@
+class LineWeeklyReportJob < ApplicationJob
+  queue_as :default
+  sidekiq_options retry: false # Jobが失敗した際、再試行せず破棄
+  include Rails.application.routes.url_helpers
+  include LineTextPushRequest
+
+  def perform(user, now)
+    total_exps            = user.user_tag_experiences.weekly(now).pluck(:experience_point).sum # 獲得経験値の合計, N+1
+    achieve_records       = user.achieve_records
+    achieve_routines_size = achive_records.size # ルーティン達成数
+    routine_titles        = achive_records.pluck(:routine_title) # 達成したルーティンのタイトル一覧
+
+    text = "今週の週間レポートです！\n\n"
+      + "獲得経験値： #{total_exps}\n\n"
+      + "　　達成数： #{achieve_routines_size}\n"
+      + make_routine_titles_str(routine_titles)
+      + "来週も頑張りましょう！！"
+
+    uid  = user.authentications.find_by(provider: 'line').uid
+
+    request_line_push_end_point(uid, text)
+  end
+
+  private
+
+  # 達成したルーティンを箇条書きで表示するための文字列を作成
+  def make_routine_titles_str(routine_titles)
+    str = "今週達成したルーティン\n"
+    return str if routine_titles.empty?
+
+    routine_titles.each do |title|
+      str += "・#{title}\n"
+    end
+
+    str
+  end
+end

--- a/app/jobs/set_notification_job.rb
+++ b/app/jobs/set_notification_job.rb
@@ -15,8 +15,7 @@ class SetNotificationJob < ApplicationJob
         when 'line'
           next unless user.link_line? # UserがLineを介して登録していない場合はスキップ
 
-          uid = user.authentications.find_by(provider: 'line').uid
-          LineNotificationJob.perform_later(uid)
+          LineNotificationJob.perform_later(user)
         when 'email'
           NotificationMailer.with(user:).notify_email.deliver_later
         end

--- a/app/jobs/weekly_report_job.rb
+++ b/app/jobs/weekly_report_job.rb
@@ -12,7 +12,7 @@ class WeeklyReportJob < ApplicationJob
 
           LineWeeklyReportJob.perform_later(user, now)
         elsif user.email?
-          # WeeklyReportMailer.with(user:).notify_email.deliver_later
+          WeeklyReportMailer.with(user:, now:).notify_email.deliver_later
         end
       end
     rescue StandardError => e

--- a/app/jobs/weekly_report_job.rb
+++ b/app/jobs/weekly_report_job.rb
@@ -1,0 +1,22 @@
+class WeeklyReportJob < ApplicationJob
+  queue_as :default
+  sidekiq_options retry: false # Jobが失敗した際、再試行せず破棄
+
+  def perform
+    now = Time.current
+
+    begin
+      User.not_off.general.includes(:authentications, :user_tag_experiences, :achieve_records).find_each do |user|
+        if user.line?
+          next unless user.link_line? # UserがLineを介して登録していない場合はスキップ
+
+          LineWeeklyReportJob.perform_later(user, now)
+        elsif user.email?
+          # WeeklyReportMailer.with(user:).notify_email.deliver_later
+        end
+      end
+    rescue StandardError => e
+      Rails.logger.error("週間レポートJobは失敗しました。エラー: #{e.message}")
+    end
+  end
+end

--- a/app/mailers/weekly_report_mailer.rb
+++ b/app/mailers/weekly_report_mailer.rb
@@ -1,0 +1,14 @@
+class WeeklyReportMailer < ApplicationMailer
+  def notify_email
+    @user = params[:user]
+    now   = params[:now]
+
+    @total_exps            = @user.user_tag_experiences.weekly(now).pluck(:experience_point).sum # 獲得経験値の合計
+    achieve_records        = @user.achieve_records.weekly(now)
+    @achieve_routines_size = achieve_records.size                  # ルーティン達成数
+    @routine_titles        = achieve_records.pluck(:routine_title) # 達成したルーティンのタイトル一覧
+
+    mail(to:      @user.email,
+         subject: '[Morning Forest] 週間レポート')
+  end
+end

--- a/app/models/achieve_record.rb
+++ b/app/models/achieve_record.rb
@@ -1,0 +1,9 @@
+class AchieveRecord < ApplicationRecord
+  belongs_to :user
+  belongs_to :routine, optional: true
+
+  validates :routine_title, presence: true
+
+  # 指定した週のデータのみを取得
+  scope :weekly, ->(now) { where(created_at: now.beginning_of_week..now.end_of_week) }
+end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -5,6 +5,7 @@ class Routine < ApplicationRecord
   has_many   :tasks, -> { order(position: :asc) }, dependent: :destroy, inverse_of: 'routine'
   has_many   :likes                              , dependent: :destroy
   has_many   :liked_users                        , through:   :likes  , source: :user
+  has_many   :achieve_records                    , dependent: :nullify
 
   validates :title      , length: { maximum: 25  }, presence: true
   validates :description, length: { maximum: 500 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   validates :reset_password_token,  uniqueness:   true    , allow_nil:  true
 
   enum role:         { admin: 0, general: 1, guest: 2 }
-  enum notification: { off:   0, line:    1, email: 2  }
+  enum notification: { off:   0, line:    1, email: 2 }
 
   def add_complete_routines_count
     self.complete_routines_count += 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many   :authentications        , dependent: :destroy
   has_many   :user_rewards           , dependent: :destroy
   has_many   :rewards                , through:   :user_rewards
+  has_many   :achieve_records        , dependent: :destroy
   has_one    :quick_routine_template , dependent: :destroy
   belongs_to :feature_reward         , class_name: 'Reward', optional: true, inverse_of: 'featuring_users'
 

--- a/app/models/user_tag_experience.rb
+++ b/app/models/user_tag_experience.rb
@@ -5,7 +5,9 @@ class UserTagExperience < ApplicationRecord
   validates :experience_point, presence: true
 
   scope :recent_one_month, -> { where(created_at: 1.month.ago..) }
-  scope :recent_one_week,  -> { where(created_at: 1.week.ago..)  }
+  scope :recent_one_week , -> { where(created_at: 1.week.ago..)  }
+  # 指定した週に作成されたデータ
+  scope :weekly, ->(now) { where(created_at: now.beginning_of_week..now.end_of_week) }
 
   # ユーザーの合計expを算出。selfにはuser.user_tag_experiencesを想定
   def self.total_experience_points

--- a/app/views/weekly_report_mailer/notify_email.html.erb
+++ b/app/views/weekly_report_mailer/notify_email.html.erb
@@ -1,0 +1,24 @@
+<p><%= @user.name %>さん、お疲れ様です♪</p>
+
+<p>今週の週間レポートをお届けします！</p>
+
+<hr>
+
+<p>
+「獲得経験値の合計： <%= @total_exp %>」
+</p>
+
+<p>
+  「ルーティン達成数： <%= @achieve_routines_size %>」
+</p>
+
+<p>取り組んだルーティン一覧</p>
+<ul>
+  <% @routine_titles.each do |title| %>
+    <li><%= title %></li>
+  <% end %>
+</ul>
+
+<hr>
+
+<p>来週も朝活頑張りましょう！！</p>

--- a/app/views/weekly_report_mailer/notify_email.text.erb
+++ b/app/views/weekly_report_mailer/notify_email.text.erb
@@ -1,0 +1,14 @@
+<%= @user.name %>さん、お疲れ様です♪
+
+今週の週間レポートをお届けします！
+
+「獲得経験値の合計： <%= @total_exp %>」
+
+「ルーティン達成数： <%= @achieve_routines_size %>」
+
+取り組んだルーティン一覧
+<% @routine_titles.each do |title| %>
+  ・<%= title %>
+<% end %>
+
+来週も朝活頑張りましょう！！

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,16 +23,16 @@ Rails.application.routes.draw do
   post   'linebot/callback', to: 'linebots#callback'
 
   resources :routines, only: %i[index new show create update destroy] do
-    resources :tasks , only: %i[create update destroy], shallow: true
-    resources :copies, only: %i[create]               , module: :routines
-    resources :plays , only: %i[create update show]   , param: :routine_id, module: :routines, shallow: true
+    resources :tasks   , only: %i[create update destroy], shallow: true
+    resources :copies  , only: %i[create]               , module: :routines
+    resources :plays   , only: %i[create update show]   , module: :routines, param: :routine_id, shallow: true
+    resources :finishes, only: %i[index]                , module: :routines
   end
 
   # URLが"routines/**"の形式では、RoutinesコントローラのshowアクションのURLとして認識されてしまうため、pathオプションを"routine"に指定
   namespace :routines, path: 'routine' do
     resources :actives      , only: %i[update]        , param: :routine_id
     resources :posts        , only: %i[index update]  , param: :routine_id
-    resources :finishes     , only: %i[index]
     resources :likes        , only: %i[create destroy], param: :routine_id
     resources :quick_creates, only: %i[create]
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,10 @@
 :scheduler:
   :schedule:
     set_notification_job:
-      cron: '0 * * * * *'  # 1分ごとに実行
+      cron: '* * * * *'  # 1分ごとに実行
       class: SetNotificationJob
+      queue: default
+    weekly_report_job:
+      cron: '0 20 * * 0'  # 毎週日曜日の20時に実行
+      class: WeeklyReportJob
       queue: default

--- a/db/migrate/20250110130856_create_achieve_records.rb
+++ b/db/migrate/20250110130856_create_achieve_records.rb
@@ -1,0 +1,11 @@
+class CreateAchieveRecords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :achieve_records do |t|
+      t.string     :routine_title, null: false
+      t.references :user         , null: false, foreign_key: true
+      t.references :routine                   , foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_03_020626) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_10_130856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "achieve_records", force: :cascade do |t|
+    t.string "routine_title", null: false
+    t.bigint "user_id", null: false
+    t.bigint "routine_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["routine_id"], name: "index_achieve_records_on_routine_id"
+    t.index ["user_id"], name: "index_achieve_records_on_user_id"
+  end
 
   create_table "authentications", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -145,6 +155,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_03_020626) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "achieve_records", "routines"
+  add_foreign_key "achieve_records", "users"
   add_foreign_key "likes", "routines"
   add_foreign_key "likes", "users"
   add_foreign_key "quick_routine_templates", "users"

--- a/spec/system/guest_logins_spec.rb
+++ b/spec/system/guest_logins_spec.rb
@@ -50,18 +50,6 @@ RSpec.describe "GuestLogins", type: :system, js: true do
       expect(page).to have_content('ゲストユーザー様はご利用できません')
       expect(page).to have_selector("#post-btn-#{routine.id}")
     end
-
-    it '投稿をコピーできない' do
-      user_other     = create(:user, :for_system_spec)
-      posted_routine = create(:routine, user: user_other, is_posted: true)
-
-      visit routines_posts_path
-      expect(page).to have_current_path(routines_posts_path)
-
-      click_on "copy-btn-#{posted_routine.id}"
-      expect(page).to have_current_path(routines_posts_path)
-      expect(page).to have_content('ゲストユーザー様はご利用できません')
-    end
   end
 
   describe 'ログアウト処理' do

--- a/spec/system/routines/routines_plays_spec.rb
+++ b/spec/system/routines/routines_plays_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
         sleep 0.1
       end
 
-      it 'routines_finishes_pathに遷移' do
-        expect(page).to have_current_path(routines_finishes_path)
+      it 'routine_finishes_pathに遷移' do
+        expect(page).to have_current_path(routine_finishes_path)
       end
 
       describe 'Header/Footerのテスト' do

--- a/spec/system/routines/routines_plays_spec.rb
+++ b/spec/system/routines/routines_plays_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
       end
 
       it 'routine_finishes_pathに遷移' do
-        expect(page).to have_current_path(routine_finishes_path)
+        expect(page).to have_current_path(routine_finishes_path(routine))
       end
 
       describe 'Header/Footerのテスト' do


### PR DESCRIPTION
## 概要
- 毎週日曜日に週間レポートを送信するJobを実装
- ゲストユーザーが投稿コピー機能を使用できるように修正

## 作成したJob
- 毎週日曜日に週間レポートを通知する
- 通知設定は開始時間の通知設定と同じ = usersテーブルのnotificationカラム（LINE, email, off）
- レポート内容
  - その週に達成したルーティン数
  - その週に獲得した経験値の合計
  - その週に達成したルーティンのタイトル一覧
- path
  - /app/jobs/weekly_report_job.rb
  - /app/jobs/line_weekly_notification_job.rb

## やったこと
- 上記のJobを作成
- 取り組み内容を保存するためのAchieveReportモデルを作成
- ゲストユーザーが投稿コピー機能を使用できるように変更

## Issue
closes #297 