### PR TITLE
エラー改善＋検索機能のエスケープ処理を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: RspecTest
 on: push
 jobs:
-  rspec-test:
+  rails_CI:
     runs-on: ubuntu-latest
     env:
       TZ: Asia/Tokyo 
@@ -74,3 +74,5 @@ jobs:
       - name: Run Rspec
         run:  RAILS_ENV=test bundle exec rspec
 
+      - name: Run Rubocop
+        run:  RAILS_ENV=test bundle exec rubocop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,9 +11,9 @@ class ApplicationController < ActionController::Base
 
   # routines/playsコントローラで生成したsessionを削除
   def playing_task_sesison_reset
-    session[:task_index] = nil if session[:task_index]
-    session[:exp_log]    = nil if session[:exp_log]
-    session[:start_time] = nil if session[:start_time]
+    [:task_index, :exp_log, :start_time].each do |el|
+      session[el] = nil if session[el]
+    end
   end
 
   def guest_block

--- a/app/controllers/quick_routine_templates_controller.rb
+++ b/app/controllers/quick_routine_templates_controller.rb
@@ -1,5 +1,5 @@
 class QuickRoutineTemplatesController < ApplicationController
-  before_action :is_create_template
+  before_action :create_template?
 
   def update
     @quick_routine_template = current_user.quick_routine_template
@@ -14,8 +14,8 @@ class QuickRoutineTemplatesController < ApplicationController
   end
 
   # Routineテンプレートがない場合作成
-  def is_create_template
-    return if current_user.quick_routine_template
+  def create_template?
+    return false if current_user.quick_routine_template
 
     current_user.create_quick_routine_template!
   end

--- a/app/controllers/routines/copies_controller.rb
+++ b/app/controllers/routines/copies_controller.rb
@@ -1,5 +1,4 @@
 class Routines::CopiesController < ApplicationController
-
   def create
     routine_origin = Routine.includes(tasks: :tags).find(params[:routine_id])
 

--- a/app/controllers/routines/likes_controller.rb
+++ b/app/controllers/routines/likes_controller.rb
@@ -2,7 +2,7 @@ class Routines::LikesController < ApplicationController
   before_action :set_routine
 
   def create
-    current_user.liked_routines << @routine
+    current_user.liked_routines << @routine unless current_user.liked_routines.include?(@routine)
     @liked_routine_ids = current_user.liked_routine_ids
     render turbo_stream: turbo_stream.update("routine-like-btn-#{@routine.id}", partial: 'routines/posts/routine_like_btn', locals: { routine: @routine, liked_routine_ids: @liked_routine_ids  })
   end

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -38,7 +38,7 @@ class Routines::PlaysController < ApplicationController
   def set_task_and_turbo_options
     # 連打によるsession[:task_index]の肥大化に対応するため、比較は>=を使用
     @task = session[:task_index] >= @tasks.size ? @tasks.last : @tasks[session[:task_index]]
-    @turbo_options =  {}
+    @turbo_options = {}
 
     # 最後のタスクの場合は完了ページに遷移するため、turbo-frameリクエストを無効化
     @turbo_options[:turbo_frame] = '_top' if session[:task_index] >= (@tasks.size - 1)

--- a/app/controllers/routines/plays_controller.rb
+++ b/app/controllers/routines/plays_controller.rb
@@ -36,11 +36,12 @@ class Routines::PlaysController < ApplicationController
   end
 
   def set_task_and_turbo_options
-    @task          = @tasks[session[:task_index]] # 取り組むTask
-    @turbo_options = { turbo_method: :patch }
+    # 連打によるsession[:task_index]の肥大化に対応するため、比較は>=を使用
+    @task = session[:task_index] >= @tasks.size ? @tasks.last : @tasks[session[:task_index]]
+    @turbo_options =  {}
 
     # 最後のタスクの場合は完了ページに遷移するため、turbo-frameリクエストを無効化
-    @turbo_options[:turbo_frame] = '_top' if session[:task_index] == (@tasks.size - 1)
+    @turbo_options[:turbo_frame] = '_top' if session[:task_index] >= (@tasks.size - 1)
   end
 
   # createアクションを介さないアクセスを拒否

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,8 @@ module ApplicationHelper
     min , sec = sec.divmod(60)
 
     hms  = []
-    hms << "#{hour}時間" if hour > 0
-    hms << "#{min}分"    if  min > 0
+    hms << "#{hour}時間" if hour.positive?
+    hms << "#{min}分"    if  min.positive?
     hms << "#{sec}秒"
 
     hms.join(' ')

--- a/app/jobs/concerns/line_text_push_request.rb
+++ b/app/jobs/concerns/line_text_push_request.rb
@@ -27,9 +27,9 @@ module LineTextPushRequest
   # リクエストボディの情報を作成
   def make_request_body_json(uid, text)
     body_hash = {
-                  to:       uid,
-                  messages: [type: 'text', text: text]
-                }
+      to: uid,
+      messages: [type: 'text', text:]
+    }
 
     JSON.generate(body_hash)
   end

--- a/app/models/achieve_record.rb
+++ b/app/models/achieve_record.rb
@@ -5,5 +5,5 @@ class AchieveRecord < ApplicationRecord
   validates :routine_title, presence: true
 
   # 指定した週のデータのみを取得
-  scope :weekly, ->(now) { where(created_at: now.beginning_of_week..now.end_of_week) }
+  scope :weekly, ->(now) { where(created_at: now.all_week) }
 end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -78,7 +78,7 @@ class Routine < ApplicationRecord
     search_query = user_words.map { '(routines.title LIKE ? OR routines.description LIKE ?)' }.join(' AND ') # 位置指定ハンドラでSQLインジェクション対策
     bind_params  = [] # クエリの?に入れる値の配列
     user_words.each do |word|
-      safety_word = self.sanitize_sql_like(word) # 入力値をLIKE用にエスケープ処理
+      safety_word = sanitize_sql_like(word) # 入力値をLIKE用にエスケープ処理
       bind_params += ["%#{safety_word}%", "%#{safety_word}%"] # titleとdescriptionの2つ分
     end
 

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -75,13 +75,13 @@ class Routine < ApplicationRecord
     return all unless user_word
 
     user_words   = user_word.split # 入力値を空白で区切る
-    search_query = user_words.map { '(routines.title LIKE ? OR routines.description LIKE ?)' }.join(' AND ')
-    like_values  = [] # クエリの?に入れる値の配列
+    search_query = user_words.map { '(routines.title LIKE ? OR routines.description LIKE ?)' }.join(' AND ') # 位置指定ハンドラでSQLインジェクション対策
+    bind_params  = [] # クエリの?に入れる値の配列
     user_words.each do |word|
-      2.times { like_values << "%#{word}%" } # titleとdescriptionの2つ分
+      bind_params += ["%#{word}%", "%#{word}%"] # titleとdescriptionの2つ分
     end
 
-    where(search_query, *like_values)
+    where(search_query, *bind_params)
   end
 
   # 絞り込み処理

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -78,7 +78,8 @@ class Routine < ApplicationRecord
     search_query = user_words.map { '(routines.title LIKE ? OR routines.description LIKE ?)' }.join(' AND ') # 位置指定ハンドラでSQLインジェクション対策
     bind_params  = [] # クエリの?に入れる値の配列
     user_words.each do |word|
-      bind_params += ["%#{word}%", "%#{word}%"] # titleとdescriptionの2つ分
+      safety_word = self.sanitize_sql_like(word) # 入力値をLIKE用にエスケープ処理
+      bind_params += ["%#{safety_word}%", "%#{safety_word}%"] # titleとdescriptionの2つ分
     end
 
     where(search_query, *bind_params)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,7 @@ class Tag < ApplicationRecord
   def self.make_empty_exp_hash
     empty_exp_hash = {}
 
-    all.find_each { |tag| empty_exp_hash[tag.name] = 0 }
+    find_each { |tag| empty_exp_hash[tag.name] = 0 }
 
     empty_exp_hash
   end

--- a/app/models/user_tag_experience.rb
+++ b/app/models/user_tag_experience.rb
@@ -7,7 +7,7 @@ class UserTagExperience < ApplicationRecord
   scope :recent_one_month, -> { where(created_at: 1.month.ago..) }
   scope :recent_one_week , -> { where(created_at: 1.week.ago..)  }
   # 指定した週に作成されたデータ
-  scope :weekly, ->(now) { where(created_at: now.beginning_of_week..now.end_of_week) }
+  scope :weekly, ->(now) { where(created_at: now.all_week) }
 
   # ユーザーの合計expを算出。selfにはuser.user_tag_experiencesを想定
   def self.total_experience_points

--- a/app/views/my_pages/_routine.html.erb
+++ b/app/views/my_pages/_routine.html.erb
@@ -57,8 +57,7 @@
 
       <% else %>
 
-        <%= link_to "スタート", routine_plays_path(routine),
-          data: { turbo_method: :post },
+        <%= button_to "スタート", routine_plays_path(routine),
           class:  "btn rounded-full mb-5 bg-gradient-to-tl from-green-400 to-green-200  shadow-lg
                   hover:from-green-400 hover:to-green-400 hover:shadow-lg w-32 h-16 
                   sm:w-36 sm:h-20 sm:text-lg md:w-40 md:h-24 md:text-xl lg:w-44 lg:h-28"

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -45,12 +45,12 @@
       <%= button_to "達成", play_path(@routine, tag_ids: @task.tag_ids),
           data: @turbo_options,
           method: :patch,
-          class: "btn-xl-custom btn-next-custom" %>
+          class: "btn-xl-custom btn-next-custom w-full" %>
 
       <%= button_to "スキップ", play_path(@routine),
           data: @turbo_options,
           method: :patch,
-          class: "btn-xl-custom btn-skip-custom" %>
+          class: "btn-xl-custom btn-skip-custom w-full" %>
     </div>
   <% end %>
 </div>

--- a/app/views/routines/plays/show.html.erb
+++ b/app/views/routines/plays/show.html.erb
@@ -42,15 +42,15 @@
     </div>
 
     <div class="flex justify-center gap-2 mx-auto flex-col w-4/12">
-      <%= link_to "達成", play_path(@routine, tag_ids: @task.tag_ids),
+      <%= button_to "達成", play_path(@routine, tag_ids: @task.tag_ids),
           data: @turbo_options,
-          class: "btn-xl-custom btn-next-custom"
-      %>
+          method: :patch,
+          class: "btn-xl-custom btn-next-custom" %>
 
-      <%= link_to "スキップ", play_path(@routine),
+      <%= button_to "スキップ", play_path(@routine),
           data: @turbo_options,
-          class: "btn-xl-custom btn-skip-custom"
-      %>
+          method: :patch,
+          class: "btn-xl-custom btn-skip-custom" %>
     </div>
   <% end %>
 </div>

--- a/app/views/routines/posts/_routine_like_btn.html.erb
+++ b/app/views/routines/posts/_routine_like_btn.html.erb
@@ -1,20 +1,17 @@
 <% if liked_routine_ids.include?(routine.id) %>
   <!-- ON -->
   <div class="tooltip" data-tip="お気に入りを解除">
-    <%= link_to routines_like_path(routine), data: { turbo_method: :delete }, class: "p-2 flex justify-center items-center", id: "like-btn-on-#{routine.id}" do %>
+    <%= button_to routines_like_path(routine), method: "delete", class: "p-2 flex justify-center items-center", id: "like-btn-on-#{routine.id}" do %>
       <span class="i-uiw-heart-on bg-pink-400 icon-size-custom"></span>
     <% end %>
   </div>
-
-
 <% else %>
   <!-- Off -->
   <div class="tooltip tooltip-secondary" data-tip="お気に入りに追加">
-    <%= link_to routines_likes_path(routine_id: routine.id), data:{ turbo_method: :post }, class: "p-2 flex justify-center items-center", id: "like-btn-off-#{routine.id}" do %>
+    <%= button_to routines_likes_path(routine_id: routine.id), method: "post", class: "p-2 flex justify-center items-center", id: "like-btn-off-#{routine.id}" do %>
       <span class="i-uiw-heart-off icon-size-custom"></span>
     <% end %>
   </div>
-  
 <% end %>
 
 

--- a/spec/system/my_pages_spec.rb
+++ b/spec/system/my_pages_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "MyPages", type: :system, js:true do
             # リンク
             expect(routine_field).to have_selector "a[href='#{routine_path(routine)}']"
             expect(routine_field).to have_selector '#notification-btn'
-            expect(routine_field).to have_selector 'a'      , text: 'スタート'
+            expect(routine_field).to have_selector 'button' , text: 'スタート'
             expect(routine_field).to have_selector 'summary', text: 'タスク一覧'
           end
 
@@ -233,7 +233,7 @@ RSpec.describe "MyPages", type: :system, js:true do
         end
         
         it 'タスク遂行画面に遷移' do
-          btn = find('a', text: 'スタート')
+          btn = find('button', text: 'スタート')
           btn.click
           expect(page).to have_current_path(play_path(routine))
         end

--- a/spec/system/routines/routines_plays_spec.rb
+++ b/spec/system/routines/routines_plays_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
       expect(main_container).to     have_selector 'button',  text: '達成'
       expect(main_container).to     have_selector 'p'     ,  text: tag1.name
       expect(main_container).to     have_selector 'p'     ,  text: tag2.name
-      expect(main_container).to     have_selector 'a'     ,  text: 'スキップ'
+      expect(main_container).to     have_selector 'button'     ,  text: 'スキップ'
     end
 
     it '「達成」を押すと次のタスクに遷移する' do

--- a/spec/system/routines/routines_plays_spec.rb
+++ b/spec/system/routines/routines_plays_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
       expect(main_container).to     have_selector 'h1',  text: task1.title
       expect(main_container).not_to have_selector 'h1',  text: task2.title
       expect(main_container).to     have_selector '#countdown-field'
-      expect(main_container).to     have_selector 'a',  text: '達成'
-      expect(main_container).to     have_selector 'p',  text: tag1.name
-      expect(main_container).to     have_selector 'p',  text: tag2.name
-      expect(main_container).to     have_selector 'a',  text: 'スキップ'
+      expect(main_container).to     have_selector 'button',  text: '達成'
+      expect(main_container).to     have_selector 'p'     ,  text: tag1.name
+      expect(main_container).to     have_selector 'p'     ,  text: tag2.name
+      expect(main_container).to     have_selector 'a'     ,  text: 'スキップ'
     end
 
     it '「達成」を押すと次のタスクに遷移する' do
@@ -63,8 +63,8 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
       main_container = find('#routine-plays-view')
       expect(main_container).not_to have_selector 'h1',  text: task1.title
       expect(main_container).to     have_selector 'h1',  text: task2.title
-      expect(main_container).to     have_selector 'a',   text: '達成'
-      expect(main_container).to     have_selector 'a',   text: 'スキップ'
+      expect(main_container).to     have_selector 'button',   text: '達成'
+      expect(main_container).to     have_selector 'button',   text: 'スキップ'
       expect(main_container).to     have_selector '#countdown-field'
     end
 
@@ -75,8 +75,8 @@ RSpec.describe "Routines::Plays", type: :system, js: true do
       main_container = find('#routine-plays-view')
       expect(main_container).not_to have_selector 'h1',  text: task1.title
       expect(main_container).to     have_selector 'h1',  text: task2.title
-      expect(main_container).to     have_selector 'a',   text: '達成'
-      expect(main_container).to     have_selector 'a',   text: 'スキップ'
+      expect(main_container).to     have_selector 'button',   text: '達成'
+      expect(main_container).to     have_selector 'button',   text: 'スキップ'
       expect(main_container).to     have_selector '#countdown-field'
     end
 


### PR DESCRIPTION
## やったこと
- 以下のボタンを高速で連打した際に、リクエストが重複して送信される不具合を解消した。具体的にはlink_toヘルパーをbutton_toヘルパーに置き換えて、フロント側でリクエストが重複しないようにした。また、サーバ側でも、重複したリクエストを受け付けない処理を追加
  - スタートボタン
  - 達成・スキップボタン
  - お気に入りボタン
- 検索機能で、フォーム入力値をSQLに埋め込む処理において、Railsでは標準で用意されていないLIKE演算子に対応したサニタイズ処理を実装し、セキュリティリスクを軽減した
- 上記の変更に合わせてテストケースを修正した